### PR TITLE
Bugfix #27: alert users when they attempt to create a duplicate tag

### DIFF
--- a/src/screens/Filter.js
+++ b/src/screens/Filter.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { TextInput, SectionList, ScrollView, View, Text, Share, Platform, StatusBar, FlatList, Dimensions } from 'react-native';
+import { TextInput, SectionList, ScrollView, View, Text, Share, Platform, StatusBar, FlatList, Dimensions, Alert } from 'react-native';
 var _ = require('lodash')
 
 import Sync from '../lib/sync'
@@ -168,6 +168,7 @@ export default class Filter extends Abstract {
           this.dismiss();
         }
       } else if(event.id == 'new-tag') {
+	var tags = ModelManager.getInstance().tags.slice();
         this.props.navigator.showModal({
           screen: 'sn.InputModal',
           title: 'New Tag',
@@ -175,6 +176,13 @@ export default class Filter extends Abstract {
           passProps: {
             title: 'New Tag',
             placeholder: "New tag name",
+	    validate: (text) => {
+	      var tagExists = !!_.find(tags, { title: text });
+	      return !tagExists;
+	    },
+	    onError: (text) => {
+              Alert.alert('Duplicate Tag', `You already have a tag named '${text}'.`, [{text: 'OK'}]);
+	    },
             onSave: (text) => {
               this.createTag(text, function(tag){
                 if(this.note) {


### PR DESCRIPTION
Prevent users from creating/saving duplicate tags (https://github.com/standardnotes/mobile/issues/27).

This is accomplished by adding a `validation` and `onError` callback to the "New Tag" modal:
- `validation` returns `false` when a tag name already exists in the tag list 
- `onError` dispatches a React-Native `Alert` when a pre-existing tag name exists, and users attempt to save it
<img width="364" alt="screen shot 2018-03-02 at 4 13 48 pm" src="https://user-images.githubusercontent.com/59469/36927771-cef8c2fc-1e34-11e8-9450-d82044e57982.png">
<img width="360" alt="screen shot 2018-03-02 at 4 14 11 pm" src="https://user-images.githubusercontent.com/59469/36927772-cf130e14-1e34-11e8-9e97-1dbe0364f8f8.png">
<img width="361" alt="screen shot 2018-03-02 at 4 14 22 pm" src="https://user-images.githubusercontent.com/59469/36927773-cf2ce41a-1e34-11e8-9262-d5a3f8b51d1b.png">
