### PR TITLE
Android deeplink and share intent

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
 
     <application
       android:name=".MainApplication"
+      android:launchMode="singleTask"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="true"
@@ -28,12 +29,27 @@
 
       <activity
         android:name=".MainActivity"
+        android:launchMode="singleTask"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="sn" />
+            <data android:scheme="standardnotes" />
+        </intent-filter>
+
+        <intent-filter>
+            <action android:name="android.intent.action.SEND" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <data android:mimeType="text/plain" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/android/app/src/main/java/com/standardnotes/MainApplication.java
+++ b/android/app/src/main/java/com/standardnotes/MainApplication.java
@@ -1,5 +1,7 @@
 package com.standardnotes;
 
+import com.standardnotes.SNSharePackage;
+
 import android.app.Application;
 import android.app.Activity;
 import android.content.Intent;
@@ -56,7 +58,8 @@ public class MainApplication extends Application implements ReactApplication {
               new RNMail(),
               new ReactNativeFingerprintScannerPackage(),
               new SNTextViewPackage(),
-              new FlagSecurePackage()
+              new FlagSecurePackage(),
+              new SNSharePackage()
       );
     }
 

--- a/android/app/src/main/java/com/standardnotes/SNShareModule.java
+++ b/android/app/src/main/java/com/standardnotes/SNShareModule.java
@@ -1,0 +1,89 @@
+package com.standardnotes;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.BaseActivityEventListener;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.bridge.Promise;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import android.content.Intent;
+import android.app.Activity;
+import javax.annotation.Nullable;
+
+public class SNShareModule extends ReactContextBaseJavaModule {
+  private ReactContext mReactContext;
+
+  private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
+    @Override
+    public void onNewIntent(Intent intent) {
+      String action = intent.getAction();
+      String type = intent.getType();
+
+      if (Intent.ACTION_SEND.equals(action) && type != null) {
+        if ("text/plain".equals(type)) {
+          String sharedText = intent.getStringExtra(Intent.EXTRA_TEXT);
+
+          if (sharedText != null) {
+            String url = "sn://compose?text=" + sharedText;
+            WritableMap params = Arguments.createMap();
+
+            params.putString("url", url);
+            mReactContext
+              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+              .emit("url", params);
+          }
+        }
+      }
+    }
+  };
+
+  public SNShareModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    mReactContext = reactContext;
+    mReactContext.addActivityEventListener(mActivityEventListener);
+  }
+
+  @Override
+  public String getName() {
+    return "SNShare";
+  }
+
+  @ReactMethod
+  public void getSharedText(Promise promise) {
+    try {
+      Activity currentActivity = getCurrentActivity();
+      String sharedText = null;
+
+      if (currentActivity != null) {
+        Intent intent = currentActivity.getIntent();
+        String action = intent.getAction();
+        String type = intent.getType();
+
+        if (Intent.ACTION_SEND.equals(action) && type != null) {
+          if ("text/plain".equals(type)) {
+            String extraText = intent.getStringExtra(Intent.EXTRA_TEXT);
+
+            if (extraText != null) {
+              sharedText = "sn://compose?text=" + extraText;
+            }
+          }
+        }
+      }
+
+      promise.resolve(sharedText);
+    } catch (Exception e) {
+      promise.reject(new JSApplicationIllegalArgumentException("Could not get shared text: " + e.getMessage()));
+    }
+  }
+}

--- a/android/app/src/main/java/com/standardnotes/SNSharePackage.java
+++ b/android/app/src/main/java/com/standardnotes/SNSharePackage.java
@@ -1,0 +1,26 @@
+package com.standardnotes;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SNSharePackage implements ReactPackage {
+
+  @Override
+  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new SNShareModule(reactContext));
+    return modules;
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-navigation-header-buttons": "^2.1.1",
     "regenerator": "^0.13.3",
     "sn-models": "0.1.12",
-    "standard-file-js": "0.3.37"
+    "standard-file-js": "0.3.37",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "babel-jest": "^23.6.0",

--- a/src/screens/Root.js
+++ b/src/screens/Root.js
@@ -160,22 +160,10 @@ export default class Root extends Abstract {
         ModelManager.get().addItem(note);
         note.setDirty(true);
 
-        Sync.get().sync().then((response) => {
-          if(response && response.error) {
-            AlertManager.get().confirm({
-              title: "Error Saving Note",
-              text: "Unable to save your new note. Please try again.",
-              confirmButtonText: "OK"
-            });
-          } else {
-            note.hasChanges = false;
-
-            // Present composer with new note
-            this.props.navigation.push("Compose", {
-              title: "Note",
-              noteId: note && note.uuid
-            });
-          }
+        // Present composer with new note
+        this.props.navigation.push("Compose", {
+          title: "Note",
+          noteId: note && note.uuid
         });
       });
     }


### PR DESCRIPTION
We talked a little bit on your live stream about this starting as an Android feature, so only that is included in this PR. It allows the app to be started by either clicking a link such as `sn://compose?title=Title&text=Text` or `standardnotes://compose?title=Title&text=Text`, as well as highlighting text elsewhere and clicking Share. It will also wait for authentication to initialize the feature.

Upon clicking a deeplink or sharing text/URL to the app, it will create a new note and then present the composer of that note.

Referencing: standardnotes/bounties#7