### PR TITLE
Prevent desktop only themes from being activated

### DIFF
--- a/src/screens/SideMenu/MainSideMenu.js
+++ b/src/screens/SideMenu/MainSideMenu.js
@@ -137,7 +137,7 @@ export default class MainSideMenu extends AbstractSideMenu {
         text: theme.name,
         key: theme.uuid || theme.name,
         iconDesc: this.iconDescriptorForTheme(theme),
-        dimmed,
+        dimmed: dimmed,
         selected: StyleKit.get().isThemeActive(theme),
         onSelect: () => {this.onThemeSelect(theme)},
         onLongPress: () => {this.onThemeLongPress(theme)}

--- a/src/screens/SideMenu/MainSideMenu.js
+++ b/src/screens/SideMenu/MainSideMenu.js
@@ -80,6 +80,16 @@ export default class MainSideMenu extends AbstractSideMenu {
   }
 
   onThemeSelect = (theme) => {
+    // Prevent themes that aren't meant for mobile from being activated
+    if(theme.content.package_info && theme.content.package_info.no_mobile) {
+      AlertManager.get().alert({
+        title: "Not Available",
+        text: "This theme is not available on mobile."
+      })
+
+      return;
+    }
+
     StyleKit.get().activateTheme(theme);
     this.forceUpdate();
   }
@@ -126,7 +136,7 @@ export default class MainSideMenu extends AbstractSideMenu {
         text: theme.name,
         key: theme.uuid || theme.name,
         iconDesc: this.iconDescriptorForTheme(theme),
-        dimmed: theme.getNotAvailOnMobile(),
+        dimmed: theme.getNotAvailOnMobile() || theme.package_info.no_mobile,
         selected: StyleKit.get().isThemeActive(theme),
         onSelect: () => {this.onThemeSelect(theme)},
         onLongPress: () => {this.onThemeLongPress(theme)}

--- a/src/screens/SideMenu/MainSideMenu.js
+++ b/src/screens/SideMenu/MainSideMenu.js
@@ -132,11 +132,12 @@ export default class MainSideMenu extends AbstractSideMenu {
     let themes = StyleKit.get().themes();
     let options = [];
     for(let theme of themes) {
+      const dimmed = theme.getNotAvailOnMobile() || (theme.content.package_info && theme.content.package_info.no_mobile);
       let option = SideMenuSection.BuildOption({
         text: theme.name,
         key: theme.uuid || theme.name,
         iconDesc: this.iconDescriptorForTheme(theme),
-        dimmed: theme.getNotAvailOnMobile() || theme.content.package_info.no_mobile,
+        dimmed,
         selected: StyleKit.get().isThemeActive(theme),
         onSelect: () => {this.onThemeSelect(theme)},
         onLongPress: () => {this.onThemeLongPress(theme)}

--- a/src/screens/SideMenu/MainSideMenu.js
+++ b/src/screens/SideMenu/MainSideMenu.js
@@ -136,7 +136,7 @@ export default class MainSideMenu extends AbstractSideMenu {
         text: theme.name,
         key: theme.uuid || theme.name,
         iconDesc: this.iconDescriptorForTheme(theme),
-        dimmed: theme.getNotAvailOnMobile() || theme.package_info.no_mobile,
+        dimmed: theme.getNotAvailOnMobile() || theme.content.package_info.no_mobile,
         selected: StyleKit.get().isThemeActive(theme),
         onSelect: () => {this.onThemeSelect(theme)},
         onLongPress: () => {this.onThemeLongPress(theme)}

--- a/src/screens/SideMenu/SideMenuCell.js
+++ b/src/screens/SideMenu/SideMenuCell.js
@@ -70,6 +70,7 @@ export default class SideMenuCell extends ThemedComponent {
 
   colorForTextClass = (textClass) => {
     if(!textClass) {return null;}
+
     return {
       "info" : StyleKit.variables.stylekitInfoColor,
       "danger" : StyleKit.variables.stylekitDangerColor,
@@ -81,6 +82,12 @@ export default class SideMenuCell extends ThemedComponent {
     let hasIcon = this.props.iconDesc;
     let iconSide = (hasIcon && this.props.iconDesc.side) ? this.props.iconDesc.side : (hasIcon ? "left" : null);
     let textColor = this.colorForTextClass(this.props.textClass);
+
+    // if this is a dimmed cell, override text color with Neutral color
+    if(this.props.dimmed) {
+      textColor = StyleKit.variable("stylekitNeutralColor");
+    }
+
     return (
       <TouchableOpacity style={this.styles.cell} onPress={this.onPress} onLongPress={this.onLongPress}>
         <View style={this.styles.cellContent}>


### PR DESCRIPTION
Original issue: https://github.com/standardnotes/mobile/issues/180

As discussed: https://github.com/standardnotes/bounties/issues/41

This adds the checks for "no_mobile" in the package_info that when set to true will prevent the theme from being activated with a prompt (as shown below). The "My No Distraction" theme is a self hosted theme so I could change the package_info to include the no_mobile data.

![screenshot](https://user-images.githubusercontent.com/5969300/64915325-b9106080-d729-11e9-8feb-a2bd134fea07.png)
![screenshot2](https://user-images.githubusercontent.com/5969300/64915345-e8bf6880-d729-11e9-9908-9b89b394a5e8.png)
