### PR TITLE
Adds a button to toggle Note sidebar in tablet mode

### DIFF
--- a/src/lib/ApplicationState.js
+++ b/src/lib/ApplicationState.js
@@ -32,6 +32,7 @@ export default class ApplicationState {
 
   /* Seperate events, unrelated to app state notifications */
   static AppStateEventTabletModeChange = "AppStateEventTabletModeChange";
+  static AppStateEventNoteSideMenuToggle = "AppStateEventNoteSideMenuToggle";
   static KeyboardChangeEvent = "KeyboardChangeEvent";
 
   static instance = null;
@@ -128,6 +129,20 @@ export default class ApplicationState {
       this.notifyEvent(
         ApplicationState.AppStateEventTabletModeChange,
         {new_isInTabletMode: enabled, old_isInTabletMode: !enabled}
+      );
+    }
+  }
+
+  get isNoteSideMenuCollapsed() {
+    return this.noteSideMenuCollapsed;
+  }
+
+  setNoteSideMenuCollapsed(collapsed) {
+    if(collapsed != this.noteSideMenuCollapsed) {
+      this.noteSideMenuCollapsed = collapsed;
+      this.notifyEvent(
+        ApplicationState.AppStateEventNoteSideMenuToggle,
+        {new_isNoteSideMenuCollapsed: collapsed, old_isNoteSideMenuCollapsed: !collapsed}
       );
     }
   }

--- a/src/style/StyleKit.js
+++ b/src/style/StyleKit.js
@@ -519,9 +519,12 @@ export default class StyleKit {
     }
   }
 
+  static platformIconPrefix() {
+    return Platform.OS == "android" ? "md" : "ios";
+  }
+
   static nameForIcon(iconName) {
-    const iconPrefix = Platform.OS == "android" ? "md" : "ios";
-    return iconPrefix + "-" + iconName;
+    return StyleKit.platformIconPrefix() + "-" + iconName;
   }
 
   static getColorLuminosity(hexCode) {


### PR DESCRIPTION
Adds a small icon on the left side of the compose window that allows the toggling of the sidebar note list. 

This even accounts for when the keyboard pops up and covers the little icon (making you unable to collapse the sidebar) it will move the icon up to sit on top of the keyboard so that you can still toggle it while writing. This is particularly helpful in landscape.

![37ci65i](https://user-images.githubusercontent.com/5969300/66258744-782acb00-e76e-11e9-8a17-36b9deeea169.png)
![6avaExq](https://user-images.githubusercontent.com/5969300/66258745-7a8d2500-e76e-11e9-8a31-72da34e947de.png)
![N3j7Xui](https://user-images.githubusercontent.com/5969300/66258816-482ff780-e76f-11e9-95bb-6ea58a02c4e8.png)
