### PR TITLE
fix: reinstall wipe

### DIFF
--- a/src/lib/installation_service.ts
+++ b/src/lib/installation_service.ts
@@ -31,10 +31,7 @@ export class InstallationService extends ApplicationService {
 
     const hasNormalKeys =
       this.application?.hasAccount() || this.application?.hasPasscode();
-
-    const keychainKey = await this.application?.deviceInterface?.getNamespacedKeychainValue(
-      this.application?.identifier
-    );
+    const keychainKey = await this.application?.deviceInterface?.getRawKeychainValue();
     const hasKeychainValue = !isNullOrUndefined(keychainKey);
 
     let firstRunKey = await this.application?.getValue(


### PR DESCRIPTION
I am aware we wanted to use namespace keychain, but this is not working as expected - the new installation will not have a legacy identifier and that means it will not discover that there is a keychain value. Until we have multiple accounts it has to stay like this.