### PR TITLE
fix: theme urls should be passed as-is to components

### DIFF
--- a/src/lib/component_manager.ts
+++ b/src/lib/component_manager.ts
@@ -1,12 +1,9 @@
 import {
   PermissionDialog,
   SNAlertService,
-  SNComponent,
   SNComponentManager,
 } from '@standardnotes/snjs';
-import { objectToCss } from '@Style/css_parser';
 import { MobileTheme } from '@Style/theme_service';
-import { Base64 } from 'js-base64';
 
 export class ComponentManager extends SNComponentManager {
   private mobileActiveTheme?: MobileTheme;
@@ -21,18 +18,6 @@ export class ComponentManager extends SNComponentManager {
       'Cancel'
     );
     dialog.callback(approved);
-  }
-
-  /** @override */
-  urlForComponent(component: SNComponent) {
-    if (component.isTheme()) {
-      const theme = component as MobileTheme;
-      const cssData = objectToCss(theme.mobileContent.variables);
-      const encoded = Base64.encodeURI(cssData);
-      return `data:text/css;base64,${encoded}`;
-    } else {
-      return super.urlForComponent(component);
-    }
   }
 
   public setMobileActiveTheme(theme: MobileTheme) {

--- a/src/lib/component_manager.ts
+++ b/src/lib/component_manager.ts
@@ -1,9 +1,12 @@
 import {
   PermissionDialog,
   SNAlertService,
+  SNComponent,
   SNComponentManager,
 } from '@standardnotes/snjs';
+import { objectToCss } from '@Style/css_parser';
 import { MobileTheme } from '@Style/theme_service';
+import { Base64 } from 'js-base64';
 
 export class ComponentManager extends SNComponentManager {
   private mobileActiveTheme?: MobileTheme;
@@ -18,6 +21,18 @@ export class ComponentManager extends SNComponentManager {
       'Cancel'
     );
     dialog.callback(approved);
+  }
+
+  /** @override */
+  urlForComponent(component: SNComponent) {
+    if (component.isTheme() && component.safeContent.isSystemTheme) {
+      const theme = component as MobileTheme;
+      const cssData = objectToCss(theme.mobileContent.variables);
+      const encoded = Base64.encodeURI(cssData);
+      return `data:text/css;base64,${encoded}`;
+    } else {
+      return super.urlForComponent(component);
+    }
   }
 
   public setMobileActiveTheme(theme: MobileTheme) {


### PR DESCRIPTION
### Summary
Some 3rd party themes are not applied correctly on the component view of the mobile app. The reason is that when fetching the stylesheet, the Sass variables are extracted and placed into `mobileContent.variables`. This is then passed to the component view, but other CSS style rules from said stylesheet are not included.

### Proof of concept
Take as an example the [Tangerine theme](https://github.com/shompoe/sn-tangerine-theme). The CSS stylesheet is located [here](https://github.com/shompoe/sn-tangerine-theme/blob/master/dist/dist.css). The stylesheet contains the variables for `sn-stylekit`. Additionally, it contains rules to change the look of some editors (see [line 108](https://github.com/shompoe/sn-tangerine-theme/blob/691026b6e908f89989458d066c387809d5608ccb/dist/dist.css#L108)):
  

```css
...

.CodeMirror .cm-header-1, .gKsMQS h1, 
.CodeMirror .cm-header-2, .gKsMQS h2,
.CodeMirror .cm-header-3, .gKsMQS h3,
.CodeMirror .cm-header-4, .gKsMQS h4,
.CodeMirror .cm-header-5, .gKsMQS h5,
.CodeMirror .cm-header-6  .gKsMQS h6 {
  color: var(--info-color);
} 
```

If you install and activate the above theme in the `web` or `desktop` app, the above CSS style rules will be applied to the component view. This is not the case for the mobile app. Only `sn-stylekit` variables are passed to the component view, according to the following block of code:

```javascript
/** @override */
urlForComponent(component: SNComponent) {
  if (component.isTheme()) {
    const theme = component as MobileTheme;
    const cssData = objectToCss(theme.mobileContent.variables);
    const encoded = Base64.encodeURI(cssData);
    return `data:text/css;base64,${encoded}`;
  } else {
    return super.urlForComponent(component);
  }
}
```

The contents of `theme.mobileContent.variables` only includes `sn-stylekit` variables, and not CSS style rules.

### Minimum requirements for a fix

- [ ] system themes should pass `sn-stylekit` variables (especially, the system dark theme) to the component view

### Proposed fix

#### `urlForComponent` method

If the theme is a system theme, we should return the Sass variables for `sn-stylekit`. Else, we should return the stylesheet URL.