### PR TITLE
docs: remove link to the outdated apk on F-Droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 
 - [iOS App Store](https://itunes.apple.com/us/app/standard-notes/id1285392450?mt=8) (iOS 10+)
 - [Google Play](https://play.google.com/store/apps/details?id=com.standardnotes) (Android 5.0+)
-- [F-Droid](https://f-droid.org/packages/com.standardnotes/) (Android 5.0+)
 - [Direct APK](https://github.com/standardnotes/mobile/releases)
 
 ## The Code


### PR DESCRIPTION
An updated app will be available on F-Droid in the future. Its progress can be tracked [here](https://github.com/standardnotes/mobile/issues/292).