### PR TITLE
Fix biometrics on quit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@react-navigation/native": "^5.8.10",
     "@react-navigation/stack": "^5.12.8",
     "@standardnotes/sncrypto-common": "1.2.9",
-    "@standardnotes/snjs": "^2.0.57",
+    "@standardnotes/snjs": "^2.0.59",
     "js-base64": "^3.5.2",
     "moment": "^2.29.1",
     "react": "16.13.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import Bugsnag from '@bugsnag/react-native';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { MobileApplication } from '@Lib/application';
 import { ApplicationGroup } from '@Lib/application_group';
-import { LockLevelType } from '@Lib/application_state';
 import { navigationRef } from '@Lib/navigation_service';
 import { DefaultTheme, NavigationContainer } from '@react-navigation/native';
 import { DeinitSource } from '@standardnotes/snjs';
@@ -69,12 +68,7 @@ const AppComponent: React.FC<{
       setThemeServiceRef(themeServiceInstance);
       await application?.prepareForLaunch({
         receiveChallenge: async challenge => {
-          const lockLevel = await application.getAppState().getLockLevel();
-          application.getAppState().setLockLevel(LockLevelType.Default);
-          application!.promptForChallenge(
-            challenge,
-            lockLevel || LockLevelType.Default
-          );
+          application!.promptForChallenge(challenge);
         },
       });
       await themeServiceInstance.init();

--- a/src/ModalStack.tsx
+++ b/src/ModalStack.tsx
@@ -1,7 +1,6 @@
 import { BlockingModal } from '@Components/BlockingModal';
 import { HeaderTitleView } from '@Components/HeaderTitleView';
 import { IoniconsHeaderButton } from '@Components/IoniconsHeaderButton';
-import { LockLevelType } from '@Lib/application_state';
 import { RouteProp } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -45,7 +44,6 @@ type ModalStackNavigatorParamList = {
   [SCREEN_AUTHENTICATE]: {
     challenge: Challenge;
     title?: string;
-    lockLevel: LockLevelType;
   };
   [MODAL_BLOCKING_ALERT]: {
     title?: string;

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -99,35 +99,30 @@ export class MobileApplication extends SNApplication {
   /** @override */
   getLaunchChallenge() {
     const challenge = super.getLaunchChallenge();
+
+    if (!challenge) {
+      return null;
+    }
+
     const previouslyLaunched = MobileApplication.getPreviouslyLaunched();
     const biometricsTiming = this.getAppState().biometricsTiming;
 
-    if (previouslyLaunched && biometricsTiming === UnlockTiming.OnQuit) {
-      MobileApplication.setPreviouslyLaunched(false);
+    MobileApplication.setPreviouslyLaunched(false);
 
-      const filteredPrompts = challenge?.prompts.filter(
+    if (previouslyLaunched && biometricsTiming === UnlockTiming.OnQuit) {
+      const filteredPrompts = challenge.prompts.filter(
         (prompt: ChallengePrompt) =>
           prompt.validation !== ChallengeValidation.Biometric
       );
 
-      if (filteredPrompts) {
-        const filteredChallenge = new Challenge(
-          filteredPrompts,
-          ChallengeReason.ApplicationUnlock,
-          false
-        );
-
-        return filteredChallenge;
-      }
+      return new Challenge(
+        filteredPrompts,
+        ChallengeReason.ApplicationUnlock,
+        false
+      );
     }
 
     return challenge;
-  }
-
-  /** @override */
-  async lock() {
-    MobileApplication.setPreviouslyLaunched(true);
-    super.lock();
   }
 
   promptForChallenge(challenge: Challenge) {

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -10,7 +10,7 @@ import {
 import { Platform } from 'react-native';
 import VersionInfo from 'react-native-version-info';
 import { AlertService } from './alert_service';
-import { ApplicationState, LockLevelType } from './application_state';
+import { ApplicationState } from './application_state';
 import { BackupsService } from './backups_service';
 import { ComponentGroup } from './component_group';
 import { ComponentManager } from './component_manager';
@@ -83,12 +83,8 @@ export class MobileApplication extends SNApplication {
     super.deinit(source);
   }
 
-  async promptForChallenge(challenge: Challenge, lockLevel: LockLevelType) {
-    push(SCREEN_AUTHENTICATE, {
-      challenge,
-      title: challenge.modalTitle,
-      lockLevel,
-    });
+  promptForChallenge(challenge: Challenge) {
+    push(SCREEN_AUTHENTICATE, { challenge, title: challenge.modalTitle });
   }
 
   setMobileServices(services: MobileServices) {

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -1,6 +1,7 @@
 import { SCREEN_AUTHENTICATE } from '@Screens/screens';
 import {
   Challenge,
+  ChallengePrompt,
   ChallengeReason,
   ChallengeValidation,
   DeinitSource,
@@ -103,10 +104,10 @@ export class MobileApplication extends SNApplication {
 
     if (previouslyLaunched && biometricsTiming === UnlockTiming.OnQuit) {
       MobileApplication.setPreviouslyLaunched(false);
-      console.log(MobileApplication.getPreviouslyLaunched());
 
       const filteredPrompts = challenge?.prompts.filter(
-        prompt => prompt.validation !== ChallengeValidation.Biometric
+        (prompt: ChallengePrompt) =>
+          prompt.validation !== ChallengeValidation.Biometric
       );
 
       if (filteredPrompts) {

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -107,8 +107,6 @@ export class MobileApplication extends SNApplication {
     const previouslyLaunched = MobileApplication.getPreviouslyLaunched();
     const biometricsTiming = this.getAppState().biometricsTiming;
 
-    MobileApplication.setPreviouslyLaunched(false);
-
     if (previouslyLaunched && biometricsTiming === UnlockTiming.OnQuit) {
       const filteredPrompts = challenge.prompts.filter(
         (prompt: ChallengePrompt) =>

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -101,7 +101,7 @@ export class MobileApplication extends SNApplication {
     const challenge = super.getLaunchChallenge();
 
     if (!challenge) {
-      return null;
+      return undefined;
     }
 
     const previouslyLaunched = MobileApplication.getPreviouslyLaunched();

--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -72,8 +72,8 @@ export class MobileApplication extends SNApplication {
     return this.previouslyLaunched;
   }
 
-  static setPreviouslyLaunched(previouslyLaunched: boolean) {
-    this.previouslyLaunched = previouslyLaunched;
+  static setPreviouslyLaunched() {
+    this.previouslyLaunched = true;
   }
 
   public hasStartedDeinit() {

--- a/src/lib/application_state.ts
+++ b/src/lib/application_state.ts
@@ -171,10 +171,11 @@ export class ApplicationState extends ApplicationService {
         }
       }
     );
+
+    await this.getUnlockTiming();
   }
 
   async onAppLaunch() {
-    await this.getUnlockTiming();
     this.setScreenshotPrivacy();
   }
 

--- a/src/lib/application_state.ts
+++ b/src/lib/application_state.ts
@@ -176,7 +176,7 @@ export class ApplicationState extends ApplicationService {
   }
 
   async onAppLaunch() {
-    MobileApplication.setPreviouslyLaunched(true);
+    MobileApplication.setPreviouslyLaunched();
     this.setScreenshotPrivacy();
   }
 

--- a/src/lib/application_state.ts
+++ b/src/lib/application_state.ts
@@ -172,10 +172,11 @@ export class ApplicationState extends ApplicationService {
       }
     );
 
-    await this.getUnlockTiming();
+    await this.loadUnlockTiming();
   }
 
   async onAppLaunch() {
+    MobileApplication.setPreviouslyLaunched(true);
     this.setScreenshotPrivacy();
   }
 
@@ -249,7 +250,7 @@ export class ApplicationState extends ApplicationService {
     }
   }
 
-  private async getUnlockTiming() {
+  private async loadUnlockTiming() {
     this.passcodeTiming = await this.getPasscodeTiming();
     this.biometricsTiming = await this.getBiometricsTiming();
   }

--- a/src/lib/application_state.ts
+++ b/src/lib/application_state.ts
@@ -36,8 +36,6 @@ import { PrefKey } from './preferences_manager';
 const pjson = require('../../package.json');
 const { PlatformConstants } = NativeModules;
 
-const LOCK_LEVEL = 'standardnotes-lock_level';
-
 // eslint-disable-next-line no-shadow
 export enum AppStateType {
   LosingFocus = 1,
@@ -82,11 +80,6 @@ export enum PasscodeKeyboardType {
 // eslint-disable-next-line no-shadow
 export enum MobileStorageKey {
   PasscodeKeyboardTypeKey = 'passcodeKeyboardType',
-}
-
-export enum LockLevelType {
-  Default = 'default',
-  PasscodeOnly = 'passcode-only',
 }
 
 type EventObserverCallback = (
@@ -516,14 +509,6 @@ export class ApplicationState extends ApplicationService {
       const hasBiometrics = await this.application.hasBiometrics();
       const hasPasscode = this.application.hasPasscode();
       if (hasPasscode && this.passcodeTiming === UnlockTiming.Immediately) {
-        if (
-          hasBiometrics &&
-          this.biometricsTiming !== UnlockTiming.Immediately
-        ) {
-          // If biometrics is not set to immediately, set lock level to passcode only before locking app
-          await this.setLockLevel(LockLevelType.PasscodeOnly);
-        }
-
         await this.application.lock();
       } else if (
         hasBiometrics &&
@@ -616,12 +601,6 @@ export class ApplicationState extends ApplicationService {
     );
   }
 
-  public async getLockLevel(): Promise<LockLevelType | undefined> {
-    return (await this.application.deviceInterface.getRawStorageValue(
-      LOCK_LEVEL
-    )) as LockLevelType;
-  }
-
   public async setPasscodeTiming(timing: UnlockTiming) {
     await this.application.setValue(
       StorageKey.MobilePasscodeTiming,
@@ -640,14 +619,6 @@ export class ApplicationState extends ApplicationService {
     );
     this.biometricsTiming = timing;
     this.setScreenshotPrivacy();
-  }
-
-  public async setLockLevel(lockLevel: LockLevelType) {
-    // Save this as standalone storage value, can't use setValue as application hasn't been launched yet
-    await this.application.deviceInterface.setRawStorageValue(
-      LOCK_LEVEL,
-      lockLevel
-    );
   }
 
   public async getPasscodeKeyboardType(): Promise<PasscodeKeyboardType> {

--- a/src/screens/Authenticate/Authenticate.tsx
+++ b/src/screens/Authenticate/Authenticate.tsx
@@ -3,11 +3,7 @@ import { IoniconsHeaderButton } from '@Components/IoniconsHeaderButton';
 import { SectionedAccessoryTableCell } from '@Components/SectionedAccessoryTableCell';
 import { SectionedTableCell } from '@Components/SectionedTableCell';
 import { SectionHeader } from '@Components/SectionHeader';
-import {
-  AppStateType,
-  LockLevelType,
-  PasscodeKeyboardType,
-} from '@Lib/application_state';
+import { AppStateType, PasscodeKeyboardType } from '@Lib/application_state';
 import { MobileDeviceInterface } from '@Lib/interface';
 import { useFocusEffect } from '@react-navigation/native';
 import { HeaderHeightContext } from '@react-navigation/stack';
@@ -76,7 +72,7 @@ function isValidChallengeValue(challengeValue: ChallengeValue): boolean {
 
 export const Authenticate = ({
   route: {
-    params: { challenge, lockLevel },
+    params: { challenge },
   },
   navigation,
 }: Props) => {
@@ -214,14 +210,6 @@ export const Authenticate = ({
 
   const authenticateBiometrics = useCallback(
     async (challengeValue: ChallengeValue) => {
-      // Bypass biometrics and mark it as valid if lock level is passcode only
-      if (lockLevel === LockLevelType.PasscodeOnly) {
-        const newChallengeValue = { ...challengeValue, value: true };
-
-        onValueChange(newChallengeValue);
-        return validateChallengeValue(newChallengeValue);
-      }
-
       let hasBiometrics = supportsBiometrics;
       if (supportsBiometrics === undefined) {
         hasBiometrics = await checkForBiometrics();
@@ -326,7 +314,6 @@ export const Authenticate = ({
     [
       application,
       checkForBiometrics,
-      lockLevel,
       onValueLocked,
       supportsBiometrics,
       validateChallengeValue,
@@ -613,107 +600,104 @@ export const Authenticate = ({
 
     return (
       <SourceContainer key={challengeValue.prompt.id}>
-        {/* If lock level is passcode only, don't show biometrics */}
-        {(!isBiometric || lockLevel !== LockLevelType.PasscodeOnly) && (
-          <StyledTableSection last={last}>
-            <SectionHeader
-              title={stateTitle}
-              subtitle={isInput ? stateLabel : undefined}
-              tinted={active}
-              buttonText={
-                challengeValue.prompt.validation ===
-                  ChallengeValidation.LocalPasscode && showSwitchKeyboard
-                  ? 'Change Keyboard'
-                  : undefined
-              }
-              buttonAction={switchKeyboard}
-              buttonStyles={
-                challengeValue.prompt.validation ===
-                ChallengeValidation.LocalPasscode
-                  ? {
-                      color: theme.stylekitNeutralColor,
-                      fontSize: theme.mainTextFontSize - 5,
-                    }
-                  : undefined
-              }
-            />
-            {isInput && (
-              <SectionContainer>
-                <SectionedTableCell textInputCell={true} first={true}>
-                  <Input
-                    key={Platform.OS === 'android' ? keyboardType : undefined}
-                    ref={
-                      Array.of(
-                        firstInputRef,
-                        secondInputRef,
-                        thirdInputRef,
-                        fourthInputRef
-                      )[index] as any
-                    }
-                    placeholder={challengeValue.prompt.placeholder}
-                    onChangeText={text => {
-                      onValueChange({ ...challengeValue, value: text });
-                    }}
-                    value={(challengeValue.value || '') as string}
-                    autoCorrect={false}
-                    autoFocus={false}
-                    autoCapitalize={'none'}
-                    secureTextEntry={challengeValue.prompt.secureTextEntry}
-                    keyboardType={
-                      challengeValue.prompt.keyboardType ?? keyboardType
-                    }
-                    keyboardAppearance={themeService?.keyboardColorForActiveTheme()}
-                    underlineColorAndroid={'transparent'}
-                    onSubmitEditing={
-                      !singleValidation
-                        ? () => {
-                            validateChallengeValue(challengeValue);
-                          }
-                        : undefined
-                    }
-                    onFocus={() => setShowSwitchKeyboard(true)}
-                    onBlur={() => setShowSwitchKeyboard(false)}
-                  />
-                </SectionedTableCell>
-              </SectionContainer>
-            )}
-            {isBiometric && (
-              <SectionContainer>
-                <SectionedAccessoryTableCell
-                  first={true}
-                  dimmed={active}
-                  tinted={active}
-                  text={stateLabel}
-                  onPress={onBiometricDirectPress}
+        <StyledTableSection last={last}>
+          <SectionHeader
+            title={stateTitle}
+            subtitle={isInput ? stateLabel : undefined}
+            tinted={active}
+            buttonText={
+              challengeValue.prompt.validation ===
+                ChallengeValidation.LocalPasscode && showSwitchKeyboard
+                ? 'Change Keyboard'
+                : undefined
+            }
+            buttonAction={switchKeyboard}
+            buttonStyles={
+              challengeValue.prompt.validation ===
+              ChallengeValidation.LocalPasscode
+                ? {
+                    color: theme.stylekitNeutralColor,
+                    fontSize: theme.mainTextFontSize - 5,
+                  }
+                : undefined
+            }
+          />
+          {isInput && (
+            <SectionContainer>
+              <SectionedTableCell textInputCell={true} first={true}>
+                <Input
+                  key={Platform.OS === 'android' ? keyboardType : undefined}
+                  ref={
+                    Array.of(
+                      firstInputRef,
+                      secondInputRef,
+                      thirdInputRef,
+                      fourthInputRef
+                    )[index] as any
+                  }
+                  placeholder={challengeValue.prompt.placeholder}
+                  onChangeText={text => {
+                    onValueChange({ ...challengeValue, value: text });
+                  }}
+                  value={(challengeValue.value || '') as string}
+                  autoCorrect={false}
+                  autoFocus={false}
+                  autoCapitalize={'none'}
+                  secureTextEntry={challengeValue.prompt.secureTextEntry}
+                  keyboardType={
+                    challengeValue.prompt.keyboardType ?? keyboardType
+                  }
+                  keyboardAppearance={themeService?.keyboardColorForActiveTheme()}
+                  underlineColorAndroid={'transparent'}
+                  onSubmitEditing={
+                    !singleValidation
+                      ? () => {
+                          validateChallengeValue(challengeValue);
+                        }
+                      : undefined
+                  }
+                  onFocus={() => setShowSwitchKeyboard(true)}
+                  onBlur={() => setShowSwitchKeyboard(false)}
                 />
-              </SectionContainer>
-            )}
-            {isProtectionSessionDuration && (
-              <SessionLengthContainer>
-                {ProtectionSessionDurations.map((duration, i) => (
-                  <SectionedAccessoryTableCell
-                    text={duration.label}
-                    key={duration.valueInSeconds}
-                    first={i === 0}
-                    last={i === ProtectionSessionDurations.length - 1}
-                    selected={() => {
-                      return duration.valueInSeconds === challengeValue.value;
-                    }}
-                    onPress={() => {
-                      onValueChange(
-                        {
-                          ...challengeValue,
-                          value: duration.valueInSeconds,
-                        },
-                        true
-                      );
-                    }}
-                  />
-                ))}
-              </SessionLengthContainer>
-            )}
-          </StyledTableSection>
-        )}
+              </SectionedTableCell>
+            </SectionContainer>
+          )}
+          {isBiometric && (
+            <SectionContainer>
+              <SectionedAccessoryTableCell
+                first={true}
+                dimmed={active}
+                tinted={active}
+                text={stateLabel}
+                onPress={onBiometricDirectPress}
+              />
+            </SectionContainer>
+          )}
+          {isProtectionSessionDuration && (
+            <SessionLengthContainer>
+              {ProtectionSessionDurations.map((duration, i) => (
+                <SectionedAccessoryTableCell
+                  text={duration.label}
+                  key={duration.valueInSeconds}
+                  first={i === 0}
+                  last={i === ProtectionSessionDurations.length - 1}
+                  selected={() => {
+                    return duration.valueInSeconds === challengeValue.value;
+                  }}
+                  onPress={() => {
+                    onValueChange(
+                      {
+                        ...challengeValue,
+                        value: duration.valueInSeconds,
+                      },
+                      true
+                    );
+                  }}
+                />
+              ))}
+            </SessionLengthContainer>
+          )}
+        </StyledTableSection>
       </SourceContainer>
     );
   };

--- a/src/screens/Authenticate/Authenticate.tsx
+++ b/src/screens/Authenticate/Authenticate.tsx
@@ -76,7 +76,7 @@ function isValidChallengeValue(challengeValue: ChallengeValue): boolean {
 
 export const Authenticate = ({
   route: {
-    params: { challenge, lockLevel = LockLevelType.Default },
+    params: { challenge, lockLevel },
   },
   navigation,
 }: Props) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,10 +1385,10 @@
   resolved "https://registry.yarnpkg.com/@standardnotes/sncrypto-common/-/sncrypto-common-1.2.9.tgz#5212a959e4ec563584e42480bfd39ef129c3cbdf"
   integrity sha512-xJ5IUGOZztjSgNP/6XL+Ut5+q9UgSTv6xMtKkcQC5aJxCOkJy9u6RamPLdF00WQgwibxx2tu0e43bKUjTgzMig==
 
-"@standardnotes/snjs@^2.0.57":
-  version "2.0.57"
-  resolved "https://registry.yarnpkg.com/@standardnotes/snjs/-/snjs-2.0.57.tgz#758d30d9074aa463ca2b642783d929a10a1a1c9f"
-  integrity sha512-s2FP024TziZnt0nJ10Tbja3IQ2KOITA67EGchadAN+vapXEicTDX2MSCPzlvk2D1M494zu15vWwQX1ryeHvHHA==
+"@standardnotes/snjs@^2.0.59":
+  version "2.0.59"
+  resolved "https://registry.yarnpkg.com/@standardnotes/snjs/-/snjs-2.0.59.tgz#ff9b60407d7810910d9bcc92e3db6bede5f28f1f"
+  integrity sha512-qt6C7KOapNaMFv+thy37scgpD/66NEwlY/RddSwxQzKFP9VWY39LYYVuDOhVgDVg18+8cK38rMTRtJag11Xy0Q==
   dependencies:
     "@standardnotes/sncrypto-common" "^1.2.9"
 


### PR DESCRIPTION
Fix biometrics always showing even when set to on quit bug. Reverted previous approach. Added previouslyLaunched static variable to MobileApplication, overrode SNJS getLaunchChallenge method and when app has been previously launched and biometrics timing is set to on quit, filtered out biometrics from the challenge prompts array.