### PR TITLE
fix: save note alerts wording

### DIFF
--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -326,7 +326,9 @@ export class Compose extends React.Component<{}, State> {
       return;
     }
     if (this.note?.deleted) {
-      this.context!.alertService!.alert('deteled replace this');
+      this.context!.alertService!.alert(
+        'Attempting to save this note has failed. The note has previously been deleted.'
+      );
       return;
     }
 
@@ -342,7 +344,9 @@ export class Compose extends React.Component<{}, State> {
       }
     }
     if (!this.context?.findItem(this.note!.uuid)) {
-      this.context?.alertService!.alert('invalid note replace');
+      this.context?.alertService!.alert(
+        'Attempting to save this note has failed. The note cannot be found.'
+      );
       return;
     }
     await this.context!.changeItem(


### PR DESCRIPTION
The wording in these alerts seemed to be on a TODO state. Updated to more user-friendly texts, but wanted to open this to feedback for the right wording.