### PR TITLE
feat: offline editors

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -291,10 +291,18 @@ PODS:
     - React
   - RNVectorIcons (7.1.0):
     - React
+  - RNZipArchive (6.0.2):
+    - React-Core
+    - RNZipArchive/Core (= 6.0.2)
+    - SSZipArchive (= 2.2.3)
+  - RNZipArchive/Core (6.0.2):
+    - React-Core
+    - SSZipArchive (= 2.2.3)
   - sn-textview (1.0.0):
     - React-Core
   - SNReactNative (1.0.0):
     - React-Core
+  - SSZipArchive (2.2.3)
   - TrustKit (1.6.5)
   - Yoga (1.14.0)
 
@@ -349,6 +357,7 @@ DEPENDENCIES:
   - RNSearchBar (from `../node_modules/react-native-search-bar`)
   - RNStoreReview (from `../node_modules/react-native-store-review/ios`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
+  - RNZipArchive (from `../node_modules/react-native-zip-archive`)
   - sn-textview (from `../node_modules/sn-textview`)
   - SNReactNative (from `../node_modules/standard-notes-rn`)
   - TrustKit (= 1.6.5)
@@ -357,6 +366,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
+    - SSZipArchive
     - TrustKit
 
 EXTERNAL SOURCES:
@@ -456,6 +466,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-store-review/ios"
   RNVectorIcons:
     :path: "../node_modules/react-native-vector-icons"
+  RNZipArchive:
+    :path: "../node_modules/react-native-zip-archive"
   sn-textview:
     :path: "../node_modules/sn-textview"
   SNReactNative:
@@ -513,8 +525,10 @@ SPEC CHECKSUMS:
   RNSearchBar: 5ed8e13ba8a6c701fbd2afdfe4164493d24b2aee
   RNStoreReview: 62d6afd7c37db711a594bbffca6b0ea3a812b7a8
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
+  RNZipArchive: 3dd2de5b7f590d79e83270508b78870bf5a54f36
   sn-textview: 43135d1feb6e97994b8475b6a1e6e3c902d6b189
   SNReactNative: 3fa6096f78bea7dbd329c897ee854f73666d20db
+  SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
   TrustKit: 073855e3adecd317417bda4ac9e9ac54a2e3b9f2
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-native-vector-icons": "^7.1.0",
     "react-native-version-info": "^1.1.0",
     "react-native-webview": "^11.0.3",
+    "react-native-zip-archive": "^6.0.2",
     "react-navigation-header-buttons": "^6.0.2",
     "sn-textview": "standardnotes/sn-textview#3b56f5c2c87c24370f00ee5a0cee0da9a9fc66c3",
     "standard-notes-rn": "standardnotes/standard-notes-rn#996b016",

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -302,6 +302,7 @@ export const ComponentView = ({
       {Boolean(url) && (
         <StyledWebview
           allowFileAccess
+          originWhitelist={['*']}
           showWebView={showWebView}
           source={{ uri: offlineUrl ? offlineUrl : url }}
           key={liveComponent?.item.uuid}

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -180,11 +180,14 @@ export const ComponentView = ({
           'OK'
         );
       } else {
-        setUrl(newUrl);
+        try {
+          const offlineEditorUrl = await getOfflineEditorUrl();
 
-        const offlineEditorUrl = await getOfflineEditorUrl();
-        if (mounted) {
-          setOfflineUrl(offlineEditorUrl);
+          if (mounted) {
+            setOfflineUrl(offlineEditorUrl);
+          }
+        } catch (e) {
+          setUrl(newUrl);
         }
       }
     };
@@ -250,12 +253,7 @@ export const ComponentView = ({
       clearTimeout(timeoutRef.current);
     }
 
-    if (offlineUrl) {
-      setOfflineUrl('');
-      setReadAccessUrl('');
-    } else {
-      onLoadError();
-    }
+    onLoadError();
   };
 
   const onShouldStartLoadWithRequest: OnShouldStartLoadWithRequest = request => {
@@ -303,7 +301,7 @@ export const ComponentView = ({
             </LockedText>
           </LockedContainer>
         )}
-      {Boolean(url) && (
+      {(Boolean(url) || Boolean(offlineUrl)) && (
         <StyledWebview
           allowFileAccess
           allowingReadAccessToURL={readAccessUrl}

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -238,7 +238,7 @@ export const ComponentView = ({
      */
     setTimeout(() => {
       onLoadEnd();
-    }, 100);
+    }, 1000);
   }, [application, liveComponent, onLoadEnd]);
 
   const onLoadStartHandler = () => {

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -285,6 +285,10 @@ export const ComponentView = ({
       window.parent.postMessage = function(data) {
         window.parent.ReactNativeWebView.postMessage(data);
       };
+      const meta = document.createElement('meta');
+      meta.setAttribute('content', 'width=device-width, initial-scale=1, user-scalable=no');
+      meta.setAttribute('name', 'viewport');
+      document.getElementsByTagName('head')[0].appendChild(meta);
       return true;
     })()`;
   };
@@ -322,9 +326,6 @@ export const ComponentView = ({
           hideKeyboardAccessoryView={true}
           onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
           cacheEnabled={true}
-          scalesPageToFit={
-            true /* Android only, not available with WKWebView */
-          }
           autoManageStatusBarEnabled={
             false /* To prevent StatusBar from changing colors when focusing */
           }

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -77,7 +77,7 @@ export const ComponentView = ({
     });
 
     return removeBlurScreenListener;
-  });
+  }, [navigation]);
 
   useFocusEffect(() => {
     setShowWebView(true);
@@ -198,9 +198,10 @@ export const ComponentView = ({
     // deinit
     return () => {
       mounted = false;
+      application?.componentManager.deactivateComponent(componentUuid);
       liveComponent?.deinit();
     };
-  }, [application, getOfflineEditorUrl, liveComponent]);
+  }, [application, componentUuid, getOfflineEditorUrl, liveComponent]);
 
   const onMessage = (event: WebViewMessageEvent) => {
     let data;

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -166,7 +166,7 @@ export const ComponentView = ({
 
   useEffect(() => {
     let mounted = true;
-    const getEditorUrl = async () => {
+    const setEditorUrl = async () => {
       const newUrl = application!.componentManager!.urlForComponent(
         liveComponent!.item
       );
@@ -186,7 +186,7 @@ export const ComponentView = ({
       }
     };
     if (liveComponent) {
-      getEditorUrl();
+      setEditorUrl();
     }
 
     // deinit

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -61,6 +61,7 @@ export const ComponentView = ({
   const [url, setUrl] = useState('');
   const [showWebView, setShowWebView] = useState<boolean>(true);
   const [offlineUrl, setOfflineUrl] = useState('');
+  const [readAccessUrl, setReadAccessUrl] = useState('');
 
   // Ref
   const webViewRef = useRef<WebView>(null);
@@ -126,6 +127,8 @@ export const ComponentView = ({
     const downloadPath = `${DocumentDirectoryPath}/${editorIdentifier}.zip`;
     const editorDir = `${DocumentDirectoryPath}/editors/${editorIdentifier}`;
     const versionDir = `${editorDir}/${editorVersion}`;
+
+    setReadAccessUrl(versionDir);
 
     const shouldDownload =
       !(await exists(versionDir)) || (await readDir(versionDir)).length === 0;
@@ -249,6 +252,7 @@ export const ComponentView = ({
 
     if (offlineUrl) {
       setOfflineUrl('');
+      setReadAccessUrl('');
     } else {
       onLoadError();
     }
@@ -302,6 +306,7 @@ export const ComponentView = ({
       {Boolean(url) && (
         <StyledWebview
           allowFileAccess
+          allowingReadAccessToURL={readAccessUrl}
           originWhitelist={['*']}
           showWebView={showWebView}
           source={{ uri: offlineUrl ? offlineUrl : url }}

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -3,7 +3,7 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { ApplicationContext } from '@Root/ApplicationContext';
 import { AppStackNavigationProp } from '@Root/AppStack';
 import { SCREEN_NOTES } from '@Screens/screens';
-import { ButtonType, ComponentArea, LiveItem, SNComponent, SNNote } from '@standardnotes/snjs';
+import { ButtonType, LiveItem, SNComponent, SNNote } from '@standardnotes/snjs';
 import React, {
   useCallback,
   useContext,
@@ -192,9 +192,6 @@ export const ComponentView = ({
     // deinit
     return () => {
       mounted = false;
-      application?.componentGroup.deactivateComponentForArea(
-        ComponentArea.Editor
-      );
       liveComponent?.deinit();
     };
   }, [application, getOfflineEditorUrl, liveComponent]);

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -186,7 +186,7 @@ export const ComponentView = ({
           if (mounted) {
             setOfflineUrl(offlineEditorUrl);
           }
-        } catch (e) {
+        } finally {
           setUrl(newUrl);
         }
       }
@@ -331,6 +331,7 @@ export const ComponentView = ({
             false /* To prevent StatusBar from changing colors when focusing */
           }
           injectedJavaScript={defaultInjectedJavaScript()}
+          onContentProcessDidTerminate={() => setOfflineUrl('')}
         />
       )}
     </FlexContainer>

--- a/src/screens/Compose/Compose.styled.ts
+++ b/src/screens/Compose/Compose.styled.ts
@@ -66,14 +66,7 @@ export const LoadingWebViewContainer = styled.View<{ locked?: boolean }>`
   justify-content: center;
   background-color: ${({ theme }) => theme.stylekitBackgroundColor};
 `;
-export const LoadingWebViewText = styled.Text`
-  padding-left: 0px;
-  color: ${({ theme }) => theme.stylekitForegroundColor};
-  opacity: 0.7;
-  font-size: 22px;
-  font-weight: bold;
-`;
-export const LoadingWebViewSubtitle = styled.Text`
+export const LoadingText = styled.Text`
   padding-left: 0px;
   color: ${({ theme }) => theme.stylekitForegroundColor};
   opacity: 0.7;

--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -233,9 +233,6 @@ export class Compose extends React.Component<{}, State> {
     if (this.downloadingMessageTimeout) {
       clearTimeout(this.downloadingMessageTimeout);
     }
-    this.context?.componentGroup.deactivateComponentForArea(
-      ComponentArea.Editor
-    );
   }
 
   /**

--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -55,6 +55,7 @@ export class Compose extends React.Component<{}, State> {
   saveTimeout: number | undefined;
   alreadySaved: boolean = false;
   statusTimeout: number | undefined;
+  downloadingMessageTimeout: number | undefined;
   removeEditorObserver?: () => void;
   removeEditorNoteValueChangeObserver?: () => void;
   removeComponentsObserver?: () => void;
@@ -228,6 +229,9 @@ export class Compose extends React.Component<{}, State> {
     }
     if (this.statusTimeout) {
       clearTimeout(this.statusTimeout);
+    }
+    if (this.downloadingMessageTimeout) {
+      clearTimeout(this.downloadingMessageTimeout);
     }
     this.context?.componentGroup.deactivateComponentForArea(
       ComponentArea.Editor
@@ -410,10 +414,19 @@ export class Compose extends React.Component<{}, State> {
       downloadingEditor: true,
     });
 
-  onDownloadEditorEnd = () =>
-    this.setState({
-      downloadingEditor: false,
-    });
+  onDownloadEditorEnd = () => {
+    if (this.downloadingMessageTimeout) {
+      clearTimeout(this.downloadingMessageTimeout);
+    }
+
+    this.downloadingMessageTimeout = setTimeout(
+      () =>
+        this.setState({
+          downloadingEditor: false,
+        }),
+      100
+    );
+  };
 
   render() {
     const shouldDisplayEditor =

--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -23,9 +23,8 @@ import { ThemeContext } from 'styled-components';
 import { ComponentView } from './ComponentView';
 import {
   Container,
+  LoadingText,
   LoadingWebViewContainer,
-  LoadingWebViewSubtitle,
-  LoadingWebViewText,
   LockedContainer,
   LockedText,
   NoteTitleInput,
@@ -46,6 +45,7 @@ type State = {
   editorComponent: SNComponent | undefined;
   webViewError: boolean;
   loadingWebview: boolean;
+  downloadingEditor: boolean;
 };
 
 export class Compose extends React.Component<{}, State> {
@@ -71,6 +71,7 @@ export class Compose extends React.Component<{}, State> {
     saveError: false,
     webViewError: false,
     loadingWebview: false,
+    downloadingEditor: false,
   };
 
   componentDidMount() {
@@ -401,6 +402,16 @@ export class Compose extends React.Component<{}, State> {
     this.saveNote(false, true, false, false, newNoteText);
   };
 
+  onDownloadEditorStart = () =>
+    this.setState({
+      downloadingEditor: true,
+    });
+
+  onDownloadEditorEnd = () =>
+    this.setState({
+      downloadingEditor: false,
+    });
+
   render() {
     const shouldDisplayEditor =
       this.state.editorComponent &&
@@ -461,12 +472,15 @@ export class Compose extends React.Component<{}, State> {
                       autoCapitalize={'sentences'}
                       editable={!this.noteLocked}
                     />
-                    {this.state.loadingWebview && (
+                    {(this.state.downloadingEditor ||
+                      this.state.loadingWebview) && (
                       <LoadingWebViewContainer locked={this.noteLocked}>
-                        <LoadingWebViewText>{'LOADING'}</LoadingWebViewText>
-                        <LoadingWebViewSubtitle>
-                          {this.state.editorComponent?.name}
-                        </LoadingWebViewSubtitle>
+                        <LoadingText>
+                          {this.state.downloadingEditor
+                            ? 'Downloading '
+                            : 'Loading '}
+                          {this.state.editorComponent?.name}...
+                        </LoadingText>
                       </LoadingWebViewContainer>
                     )}
                     {/* setting webViewError to false on onLoadEnd will cause an infinite loop on Android upon webview error, so, don't do that. */}
@@ -492,6 +506,8 @@ export class Compose extends React.Component<{}, State> {
                             webViewError: true,
                           });
                         }}
+                        onDownloadEditorStart={this.onDownloadEditorStart}
+                        onDownloadEditorEnd={this.onDownloadEditorEnd}
                       />
                     )}
                     {!shouldDisplayEditor &&

--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -229,6 +229,9 @@ export class Compose extends React.Component<{}, State> {
     if (this.statusTimeout) {
       clearTimeout(this.statusTimeout);
     }
+    this.context?.componentGroup.deactivateComponentForArea(
+      ComponentArea.Editor
+    );
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,6 +6944,11 @@ react-native-webview@^11.0.3:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
+react-native-zip-archive@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-6.0.2.tgz#3594a3072f229c6e99b2121ab955b74ba422850d"
+  integrity sha512-TQVmUvbpVV2WryGaZs6HIzIYaGU55Sz3FmZA4ayqEhJDvkGQxlElXzanIIXsHWcOybrb+9572X0trLNbXIYrRQ==
+
 react-native@0.63.4:
   version "0.63.4"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.63.4.tgz#2210fdd404c94a5fa6b423c6de86f8e48810ec36"


### PR DESCRIPTION
- Added react-native-zip-archive-dependency
- Added offline editors feature. Editor's zip file is downloaded and extracted. Zip files are deleted after extraction to save up space. If there's a new version of an editor, it's downloaded and the previous version's files are deleted. If there is an error with downloading/loading the offline editor, it should fallback to loading the online editor.
- Changed loading editor text to "Downloading/Loading [editor]..."

Some issues to fix (WIP):
- Some editors look zoomed out when loaded from offline source
- There's a small time gap between the "Downloading..." and the "Loading..." message