### PR TITLE
fix: close editor when unmounting compose component

### DIFF
--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -222,6 +222,9 @@ export class Compose extends React.Component<{}, State> {
     this.removeComponentGroupObserver = undefined;
     this.removeEditorNoteChangeObserver = undefined;
     this.removeEditorNoteValueChangeObserver = undefined;
+    if (this.editor) {
+      this.context?.editorGroup?.closeEditor(this.editor);
+    }
 
     this.context?.getStatusManager()?.setMessage(SCREEN_COMPOSE, '');
     if (this.saveTimeout) {


### PR DESCRIPTION
Currently editors aren't being removed from the editor group when unmounting the compose screen, which broke the `useHasEditor` hook and subsequently the side drawer that would rely on this hook to determine whether to lock itself or not