### PR TITLE
feat: remove editor loading message on ThemesActivated action

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@react-navigation/native": "^5.9.3",
     "@react-navigation/stack": "^5.14.3",
     "@standardnotes/sncrypto-common": "1.2.9",
-    "@standardnotes/snjs": "2.0.75",
+    "@standardnotes/snjs": "2.0.76",
     "js-base64": "^3.5.2",
     "moment": "^2.29.1",
     "react": "16.13.1",

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -244,7 +244,7 @@ export const ComponentView = ({
      */
     setTimeout(() => {
       onLoadEnd();
-    }, 100);
+    }, 200);
   }, [application, liveComponent, onLoadEnd]);
 
   const onLoadStartHandler = () => {

--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -181,11 +181,18 @@ export class Compose extends React.Component<{}, State> {
         identifier: 'component-view-' + Math.random(),
         areas: [ComponentArea.Editor],
         actionHandler: (currentComponent, action, data) => {
-          if (action === ComponentAction.SetSize) {
-            this.context?.componentManager!.handleSetSizeEvent(
-              currentComponent,
-              data
-            );
+          switch (action) {
+            case ComponentAction.SetSize:
+              this.context?.componentManager!.handleSetSizeEvent(
+                currentComponent,
+                data
+              );
+              break;
+            case ComponentAction.ThemesActivated:
+              this.setState({
+                loadingWebview: false,
+              });
+              break;
           }
         },
         contextRequestHandler: () => this.note,
@@ -432,7 +439,7 @@ export class Compose extends React.Component<{}, State> {
         this.setState({
           downloadingEditor: false,
         }),
-      100
+      200
     );
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,10 +1390,10 @@
   resolved "https://registry.yarnpkg.com/@standardnotes/sncrypto-common/-/sncrypto-common-1.2.9.tgz#5212a959e4ec563584e42480bfd39ef129c3cbdf"
   integrity sha512-xJ5IUGOZztjSgNP/6XL+Ut5+q9UgSTv6xMtKkcQC5aJxCOkJy9u6RamPLdF00WQgwibxx2tu0e43bKUjTgzMig==
 
-"@standardnotes/snjs@2.0.75":
-  version "2.0.75"
-  resolved "https://registry.yarnpkg.com/@standardnotes/snjs/-/snjs-2.0.75.tgz#aeb0ead927da63dc85e28f78da2362126bb16602"
-  integrity sha512-QL5YgDT0aN9t95gxgURqNudXr5dteVsc1ylsKKSw0DpEGiq0bACPxbI+sUFppoWTFmprxmDh3+vc+FFcFg7Lyw==
+"@standardnotes/snjs@2.0.76":
+  version "2.0.76"
+  resolved "https://registry.yarnpkg.com/@standardnotes/snjs/-/snjs-2.0.76.tgz#69b007b83ef6dc8261a4368750e75db7ccbb3456"
+  integrity sha512-JY0PldVN7zHfN42JNd77jqqwDAaalwiWKg9Odib13ag3X/Vm8OWzyRMPa/4ggMWdwGV8dvraw9IxIYTU0VT+TA==
   dependencies:
     "@standardnotes/auth" "^2.0.0"
     "@standardnotes/sncrypto-common" "^1.2.9"


### PR DESCRIPTION
Kept the timeout which should handle removing the message after 200ms if the ThemesActivated action hasn't fired before that. Increased the downloading editor message to 200ms to prevent the minor "skipping" from the downloading to the loading message.