### PR TITLE
fix: live item deinit called more than once

### DIFF
--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -224,8 +224,6 @@ export const ComponentView = ({
     // deinit
     return () => {
       mounted = false;
-      application?.componentManager.deactivateComponent(componentUuid);
-      liveComponent?.deinit();
     };
   }, [
     application,
@@ -235,6 +233,13 @@ export const ComponentView = ({
     offlineOnly,
     onLoadErrorHandler,
   ]);
+
+  useEffect(() => {
+    return () => {
+      application?.componentManager.deactivateComponent(componentUuid);
+      liveComponent?.deinit();
+    };
+  }, [application, componentUuid, liveComponent]);
 
   const onMessage = (event: WebViewMessageEvent) => {
     let data;


### PR DESCRIPTION
Potential fix for removeObserver is undefined errors (liveItem deinit being called more than once).