### PR TITLE
fix: downgrade react to officially supported version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:3.5.3')
+        classpath('com.android.tools.build:gradle:4.1.3')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@standardnotes/snjs": "2.0.76",
     "js-base64": "^3.5.2",
     "moment": "^2.29.1",
-    "react": "^17.0.2",
+    "react": "17.0.1",
     "react-native": "0.64.1",
     "react-native-aes-crypto": "standardnotes/react-native-aes#6430299",
     "react-native-alternate-icons": "standardnotes/react-native-alternate-icons#1d335d",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6985,10 +6985,10 @@ react-test-renderer@16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
React Native versions are tied to specific React version (those are synced by Facebook). Using another version is not recommended.
Also updated gradle build tools. For more streamlined upgrade experience you can use https://react-native-community.github.io/upgrade-helper/?from=0.63.4&to=0.64.1