### PR TITLE
fix: usage description for camera and photos (iOS)

### DIFF
--- a/ios/StandardNotes/Info.plist
+++ b/ios/StandardNotes/Info.plist
@@ -89,7 +89,7 @@
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>Camera is required to scan QR codes with the TokenVault extension.</string>
+	<string>Camera is optionally used to upload images and scan QR codes using the TokenVault extension.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Face ID is required to unlock your notes.</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/ios/StandardNotes/Info.plist
+++ b/ios/StandardNotes/Info.plist
@@ -97,7 +97,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Not used by application; required in configuration because API exists in build dependencies.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Photo library is required to select QR code images from your photo library.</string>
+	<string>Photo library is optionally used to select files to upload or QR code images from your photo library.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>

--- a/ios/StandardNotes/Info.plist
+++ b/ios/StandardNotes/Info.plist
@@ -88,12 +88,16 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera is required to scan QR codes with the TokenVault extension.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Face ID is required to unlock your notes.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Not used by application; required in configuration because API exists in build dependencies.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Not used by application; required in configuration because API exists in build dependencies.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Photo library is required to select QR code images from your photo library.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>

--- a/ios/StandardNotesDev-Info.plist
+++ b/ios/StandardNotesDev-Info.plist
@@ -66,12 +66,16 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera is required to scan QR codes with the TokenVault extension.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Face ID is required to unlock your notes.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Not used by application; required in configuration because API exists in build dependencies.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Not used by application; required in configuration because API exists in build dependencies.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Photo library is required to select QR code images from your photo library.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>


### PR DESCRIPTION
The Standard Notes app on iOS throws the following, when using the camera to scan a QR code for the TokenVault extension:

`Termination Reason: TCC, This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data.`

- adds `NSCameraUsageDescription` description
- adds `NSPhotoLibraryUsageDescription` description

Maybe we want to keep descriptions generic for other use cases. Thoughts @mobitar ?

---

should fix https://github.com/standardnotes/token-vault/issues/15