### PR TITLE
feat: serve offline editors from local static server

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,6 +11,9 @@ PODS:
     - React-Core (= 0.64.1)
     - React-jsi (= 0.64.1)
     - ReactCommon/turbomodule/core (= 0.64.1)
+  - GCDWebServer (3.5.4):
+    - GCDWebServer/Core (= 3.5.4)
+  - GCDWebServer/Core (3.5.4)
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -219,6 +222,9 @@ PODS:
     - React-Core
   - react-native-sodium (0.5.0):
     - React-Core
+  - react-native-static-server (0.5.0):
+    - GCDWebServer (~> 3.0)
+    - React
   - react-native-version-info (1.1.0):
     - React-Core
   - react-native-webview (11.0.3):
@@ -357,6 +363,7 @@ DEPENDENCIES:
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-segmented-control (from `../node_modules/@react-native-community/segmented-control`)"
   - react-native-sodium (from `../node_modules/react-native-sodium`)
+  - react-native-static-server (from `../node_modules/react-native-static-server`)
   - react-native-version-info (from `../node_modules/react-native-version-info`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -394,6 +401,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
+    - GCDWebServer
     - SSZipArchive
     - TrustKit
 
@@ -444,6 +452,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/segmented-control"
   react-native-sodium:
     :path: "../node_modules/react-native-sodium"
+  react-native-static-server:
+    :path: "../node_modules/react-native-static-server"
   react-native-version-info:
     :path: "../node_modules/react-native-version-info"
   react-native-webview:
@@ -515,6 +525,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
   FBReactNativeSpec: 893650afcc5d434b48a5b9162db9b89b816bb89a
+  GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: ec2ebc96b7bfba3ca5c32740f5a0c6a014a274d2
@@ -534,6 +545,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
   react-native-segmented-control: 65df6cd0619b780b3843d574a72d4c7cec396097
   react-native-sodium: 6cc4c4c1ea331f9f2b478076e983e09827a7b23f
+  react-native-static-server: 201b2a945a35096be3ae7f43e367c65bcbd61343
   react-native-version-info: 36490da17d2c6b5cc21321c70e433784dee7ed0b
   react-native-webview: 21fdfbdd5a2268195ca013174f8f656f3509de50
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-native-search-bar": "standardnotes/react-native-search-bar#7d2139d",
     "react-native-search-box": "standardnotes/react-native-search-box#c0de5bab18cb418fef75ef2c2cd921304142e492",
     "react-native-sodium": "standardnotes/react-native-sodium#7e169138801011df42e5eb0ba229b8910c3bec2f",
+    "react-native-static-server": "^0.5.0",
     "react-native-store-review": "^0.1.5",
     "react-native-tab-view": "^2.15.2",
     "react-native-vector-icons": "^7.1.0",

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -20,10 +20,7 @@ import React, {
   useState,
 } from 'react';
 import { Platform } from 'react-native';
-import RNFS, {
-  DocumentDirectoryPath,
-  ExternalDirectoryPath,
-} from 'react-native-fs';
+import RNFS, { DocumentDirectoryPath } from 'react-native-fs';
 import StaticServer from 'react-native-static-server';
 import { WebView } from 'react-native-webview';
 import {
@@ -54,8 +51,7 @@ type Props = {
 };
 
 const STATIC_SERVER_PORT = 8080;
-const BASE_PATH =
-  Platform.OS === 'android' ? ExternalDirectoryPath : DocumentDirectoryPath;
+const BASE_PATH = DocumentDirectoryPath;
 const EDITORS_PATH = '/editors';
 
 async function checkForComponentUpdate(

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -24,6 +24,7 @@ import RNFS, {
   DocumentDirectoryPath,
   ExternalDirectoryPath,
 } from 'react-native-fs';
+import StaticServer from 'react-native-static-server';
 import { WebView } from 'react-native-webview';
 import {
   OnShouldStartLoadWithRequest,
@@ -51,6 +52,11 @@ type Props = {
   onDownloadEditorEnd: () => void;
   offlineOnly?: boolean;
 };
+
+const STATIC_SERVER_PORT = 8080;
+const BASE_PATH =
+  Platform.OS === 'android' ? ExternalDirectoryPath : DocumentDirectoryPath;
+const EDITORS_PATH = '/editors';
 
 async function checkForComponentUpdate(
   application: SNApplication,
@@ -98,12 +104,12 @@ export const ComponentView = ({
   const [url, setUrl] = useState('');
   const [showWebView, setShowWebView] = useState<boolean>(true);
   const [offlineUrl, setOfflineUrl] = useState('');
-  const [readAccessUrl, setReadAccessUrl] = useState('');
   const [
     downloadingOfflineEditor,
     setDownloadingOfflineEditor,
   ] = useState<boolean>(false);
   const [loadedOnce, setLoadedOnce] = useState(false);
+  const [staticServer, setStaticServer] = useState<StaticServer>();
 
   // Ref
   const webViewRef = useRef<WebView>(null);
@@ -162,6 +168,30 @@ export const ComponentView = ({
     }
   }, [application]);
 
+  const downloadEditor = useCallback(
+    async (downloadUrl, downloadPath, editorPath, versionPath) => {
+      setDownloadingOfflineEditor(true);
+      onDownloadEditorStart();
+      try {
+        // Delete any previous versions downloads
+        if (await RNFS.exists(editorPath)) {
+          await RNFS.unlink(editorPath);
+        }
+        await RNFS.downloadFile({
+          fromUrl: downloadUrl,
+          toFile: downloadPath,
+        }).promise;
+        await unzip(downloadPath, versionPath);
+        // Delete zip after extraction
+        await RNFS.unlink(downloadPath);
+      } finally {
+        onDownloadEditorEnd();
+        setDownloadingOfflineEditor(false);
+      }
+    },
+    [onDownloadEditorStart, onDownloadEditorEnd]
+  );
+
   const getOfflineEditorUrl = useCallback(async () => {
     if (!liveComponent) {
       return '';
@@ -172,63 +202,46 @@ export const ComponentView = ({
       version: editorVersion,
       download_url: downloadUrl,
     } = liveComponent.item.package_info;
-    const basePath =
-      Platform.OS === 'android' ? ExternalDirectoryPath : DocumentDirectoryPath;
-    const downloadPath = `${basePath}/${editorIdentifier}.zip`;
-    const editorDir = `${basePath}/editors/${editorIdentifier}`;
-    const versionDir = `${editorDir}/${editorVersion}`;
-
-    setReadAccessUrl(versionDir);
-
+    const downloadPath = `${BASE_PATH}/${editorIdentifier}.zip`;
+    const editorPath = `${BASE_PATH}${EDITORS_PATH}/${editorIdentifier}`;
+    const versionPath = `${editorPath}/${editorVersion}`;
     const shouldDownload =
       !downloadingOfflineEditor &&
-      (!(await RNFS.exists(versionDir)) ||
-        (await RNFS.readDir(versionDir)).length === 0);
+      (!(await RNFS.exists(versionPath)) ||
+        (await RNFS.readDir(versionPath)).length === 0);
+
+    if (shouldDownload) {
+      await downloadEditor(downloadUrl, downloadPath, editorPath, versionPath);
+    }
 
     if (application) {
       checkForComponentUpdate(application, liveComponent.item);
     }
 
-    if (shouldDownload) {
-      setDownloadingOfflineEditor(true);
-      onDownloadEditorStart();
-      try {
-        // Delete any previous versions downloads
-        if (await RNFS.exists(editorDir)) {
-          await RNFS.unlink(editorDir);
-        }
-        await RNFS.downloadFile({
-          fromUrl: downloadUrl,
-          toFile: downloadPath,
-        }).promise;
-        await unzip(downloadPath, versionDir);
-        // Delete zip after extraction
-        await RNFS.unlink(downloadPath);
-      } finally {
-        onDownloadEditorEnd();
-        setDownloadingOfflineEditor(false);
+    if (await RNFS.exists(versionPath)) {
+      const editorDir = await RNFS.readDir(versionPath);
+      const packagePath = editorDir[0].path;
+      const packageJson = JSON.parse(
+        await RNFS.readFile(`${packagePath}/package.json`)
+      );
+      const mainFileName = packageJson?.sn?.main || 'index.html';
+      const mainFilePath = `${packagePath}/${mainFileName}`;
+      const splitPackagePath = packagePath.split(EDITORS_PATH);
+      const relativePackagePath = splitPackagePath[splitPackagePath.length - 1];
+      const relativeMainFilePath = `${relativePackagePath}/${mainFileName}`;
+
+      if ((await RNFS.exists(mainFilePath)) && staticServer?.isRunning) {
+        return `${staticServer.origin}${relativeMainFilePath}`;
       }
-    }
-
-    const packageDir = await RNFS.readDir(versionDir);
-    const packageJsonPath = `${packageDir[0].path}/package.json`;
-    const packageJson = JSON.parse(await RNFS.readFile(packageJsonPath));
-
-    const mainFileName = packageJson?.sn?.main || 'index.html';
-
-    const mainFilePath = `${packageDir[0].path}/${mainFileName}`;
-
-    if (await RNFS.exists(mainFilePath)) {
-      return `file://${mainFilePath}`;
     }
 
     return '';
   }, [
     application,
+    downloadEditor,
     downloadingOfflineEditor,
     liveComponent,
-    onDownloadEditorStart,
-    onDownloadEditorEnd,
+    staticServer,
   ]);
 
   const onLoadErrorHandler = useCallback(() => {
@@ -293,6 +306,24 @@ export const ComponentView = ({
       liveComponent?.deinit();
     };
   }, [application, componentUuid, liveComponent]);
+
+  useEffect(() => {
+    const path = `${BASE_PATH}${EDITORS_PATH}`;
+    let server: StaticServer;
+
+    const startStaticServer = async () => {
+      server = new StaticServer(STATIC_SERVER_PORT, path, {
+        localOnly: true,
+      });
+      await server.start();
+      setStaticServer(server);
+    };
+    startStaticServer();
+
+    return () => {
+      server?.stop();
+    };
+  }, []);
 
   const onMessage = (event: WebViewMessageEvent) => {
     let data;
@@ -405,9 +436,6 @@ export const ComponentView = ({
       )}
       {(Boolean(url) || Boolean(offlineUrl)) && (
         <StyledWebview
-          allowFileAccess
-          allowingReadAccessToURL={readAccessUrl}
-          originWhitelist={['*']}
           showWebView={showWebView}
           source={
             /**

--- a/src/screens/Compose/ComponentView.tsx
+++ b/src/screens/Compose/ComponentView.tsx
@@ -47,6 +47,8 @@ type Props = {
   onLoadError: () => void;
   onDownloadEditorStart: () => void;
   onDownloadEditorEnd: () => void;
+  onDownloadError: () => void;
+  downloadError: boolean;
   offlineOnly?: boolean;
 };
 
@@ -87,6 +89,8 @@ export const ComponentView = ({
   onLoadStart,
   onDownloadEditorStart,
   onDownloadEditorEnd,
+  onDownloadError,
+  downloadError,
   componentUuid,
   offlineOnly,
 }: Props) => {
@@ -180,12 +184,14 @@ export const ComponentView = ({
         await unzip(downloadPath, versionPath);
         // Delete zip after extraction
         await RNFS.unlink(downloadPath);
+      } catch (error) {
+        onDownloadError();
       } finally {
         onDownloadEditorEnd();
         setDownloadingOfflineEditor(false);
       }
     },
-    [onDownloadEditorStart, onDownloadEditorEnd]
+    [onDownloadEditorStart, onDownloadEditorEnd, onDownloadError]
   );
 
   const getOfflineEditorUrl = useCallback(async () => {
@@ -202,6 +208,7 @@ export const ComponentView = ({
     const editorPath = `${BASE_PATH}${EDITORS_PATH}/${editorIdentifier}`;
     const versionPath = `${editorPath}/${editorVersion}`;
     const shouldDownload =
+      !downloadError &&
       !downloadingOfflineEditor &&
       (!(await RNFS.exists(versionPath)) ||
         (await RNFS.readDir(versionPath)).length === 0);
@@ -235,6 +242,7 @@ export const ComponentView = ({
   }, [
     application,
     downloadEditor,
+    downloadError,
     downloadingOfflineEditor,
     liveComponent,
     staticServer,

--- a/src/types/react-native-static-server/index.d.ts
+++ b/src/types/react-native-static-server/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'react-native-static-server' {
+  export default class StaticServer {
+    constructor(port: number, path?: string, { localOnly: boolean });
+    start: () => Promise<string>;
+    stop: () => void;
+    isRunning: () => Promise<boolean>;
+    origin: string;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,6 +6890,11 @@ react-native-sodium@standardnotes/react-native-sodium#7e169138801011df42e5eb0ba2
   version "0.5.0"
   resolved "https://codeload.github.com/standardnotes/react-native-sodium/tar.gz/7e169138801011df42e5eb0ba229b8910c3bec2f"
 
+react-native-static-server@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-static-server/-/react-native-static-server-0.5.0.tgz#4b396082bfe7dfdbba6fe7d7de894de5ba4ebadb"
+  integrity sha512-RGteckPoBZq48p9Y8V67bjZGPxLHKkEOAffLSUJiGC7hkx+H+zuekqCR+04F30NuWB7y+nb8N7Qld2RGjX5DNg==
+
 react-native-store-review@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/react-native-store-review/-/react-native-store-review-0.1.5.tgz#9df69786a137580748e368641698d2104519e4cf"


### PR DESCRIPTION
This is a POC for serving offline editors from a local static server and accessing them through the HTTP protocol on the WebView, instead of using the file protocol.

The issue when using the file protocol is the WebView disallows running web workers, which some editors use. The Bold Editor for example uses FileSafe which in turn uses web workers to encrypt/decrypt attachments.

By doing this, we'd be creating a local server (accessible only by the app and not from outside of it) serving the editors which can then be accessed through a URL, just like online editors. This fixes the following issues for offline editors reported so far (and probably other potential issues related to the same cause):
- Bold Editor can't encrypt/decrypt attachments
- Plus Editor doesn't show embedded videos