### PR TITLE
fix: remove trailing slash on defaultHost url

### DIFF
--- a/src/lib/application.ts
+++ b/src/lib/application.ts
@@ -60,7 +60,7 @@ export class MobileApplication extends SNApplication {
         },
       ],
       VersionInfo.bundleIdentifier?.includes('dev')
-        ? 'https://api-dev.standardnotes.com/'
+        ? 'https://api-dev.standardnotes.com'
         : 'https://api.standardnotes.com',
       version
     );


### PR DESCRIPTION
A trailing slash (`/`) causes the dev app to throw an "Unknown error" when performing sign in/register requests. 

Btw, we should consider parsing the `defaultHost` URL to remove any trailing slashes `snjs`