### PR TITLE
fix: show editor name when editor fails to load

### DIFF
--- a/src/screens/Compose/Compose.tsx
+++ b/src/screens/Compose/Compose.tsx
@@ -145,11 +145,11 @@ export class Compose extends React.Component<{}, State> {
 
     this.removeComponentGroupObserver = this.context?.componentGroup.addChangeObserver(
       async () => {
-        const newEditor = this.context?.componentGroup.activeComponentForArea(
-          ComponentArea.Editor
+        const editorForNote = this.context?.componentManager.editorForNote(
+          this.note!
         );
         this.setState({
-          editorComponent: newEditor,
+          editorComponent: editorForNote,
         });
       }
     );


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/5891646/132447589-e6f1a6d6-d293-4b02-843b-7f724f2bc807.png" width="50%" height="50%">

Asana task: https://app.asana.com/0/1199914526147392/1199625073300525