### PR TITLE
fix: when exporting via Email, use `Base64.encode` for URL safe stringified data

### DIFF
--- a/src/lib/backups_service.ts
+++ b/src/lib/backups_service.ts
@@ -40,7 +40,7 @@ export class BackupsService extends ApplicationService {
         const result = await this._showAndroidEmailOrSaveOption();
         if (result === 'email') {
           return this._exportViaEmailAndroid(
-            Base64.encodeURI(stringifiedData),
+            Base64.encode(stringifiedData),
             filename
           );
         } else if (result === 'save') {


### PR DESCRIPTION
(Asana tasks: https://app.asana.com/0/1199914526147392/1201318023371010)