### PR TITLE
fix: import Aes from NativeModules

### DIFF
--- a/src/lib/react_native_crypto.ts
+++ b/src/lib/react_native_crypto.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-bitwise */
-import Aes from '@standardnotes/react-native-aes';
 import {
   Base64String,
   HexString,
@@ -9,7 +8,10 @@ import {
   timingSafeEqual,
   Utf8String,
 } from '@standardnotes/sncrypto-common';
+import { NativeModules } from 'react-native';
 import * as Sodium from 'react-native-sodium-jsi';
+
+const { Aes } = NativeModules;
 
 export class SNReactNativeCrypto implements SNPureCrypto {
   deinit(): void {}


### PR DESCRIPTION
Otherwise it gives an exception (more details [here](https://github.com/tectiv3/react-native-aes/issues/60#issuecomment-989124984))