### PR TITLE
fix: don't wrap multi-line file names after some actions (such as detaching from note)

### DIFF
--- a/src/screens/SideMenu/Files.styled.ts
+++ b/src/screens/SideMenu/Files.styled.ts
@@ -1,8 +1,13 @@
 import { SnIcon } from '@Components/SnIcon';
 import { SideMenuCell } from '@Screens/SideMenu/SideMenuCell';
-import { Platform } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import styled from 'styled-components/native';
 
+export const styles = StyleSheet.create({
+  cellContentStyle: {
+    flexShrink: 0,
+  },
+});
 export const SNIconStyled = styled(SnIcon)`
   margin-left: 8px;
 `;

--- a/src/screens/SideMenu/Files.tsx
+++ b/src/screens/SideMenu/Files.tsx
@@ -10,6 +10,7 @@ import {
   SideMenuCellShowAllFiles,
   SideMenuCellStyled,
   SNIconStyled,
+  styles,
 } from '@Screens/SideMenu/Files.styled';
 import { SideMenuOptionIconDescriptionType } from '@Screens/SideMenu/SideMenuSection';
 import { SNNote } from '@standardnotes/snjs';
@@ -65,6 +66,7 @@ export const Files: FC<Props> = ({ note }) => {
                   </IconsContainer>
                 ),
               }}
+              cellContentStyle={styles.cellContentStyle}
             />
           </FileItemContainer>
         );
@@ -74,6 +76,7 @@ export const Files: FC<Props> = ({ note }) => {
           isFilesListTruncated ? 'Show all attached files' : 'Show other files'
         }
         onSelect={openFilesScreen}
+        cellContentStyle={styles.cellContentStyle}
       />
     </FilesContainer>
   );

--- a/src/screens/SideMenu/SideMenuCell.tsx
+++ b/src/screens/SideMenu/SideMenuCell.tsx
@@ -80,7 +80,7 @@ export const SideMenuCell: React.FC<SideMenuOption> = props => {
       onLongPress={props.onLongPress}
       style={[props.style || {}]}
     >
-      <CellContent iconSide={iconSide}>
+      <CellContent iconSide={iconSide} style={props.cellContentStyle || {}}>
         {iconSide === 'left' && (
           <IconContainerLeft>
             {renderIcon(props.iconDesc, theme.stylekitInfoColor)}

--- a/src/screens/SideMenu/SideMenuSection.tsx
+++ b/src/screens/SideMenu/SideMenuSection.tsx
@@ -29,6 +29,7 @@ export type SideMenuOption = {
   onSelect?: () => void | Promise<void>;
   onLongPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  cellContentStyle?: StyleProp<ViewStyle>;
 };
 
 type Props = {


### PR DESCRIPTION
[Internal link](https://app.asana.com/0/1199942776723820/1202138269476662)