### PR TITLE
fix: don't truncate files list in note side menu

### DIFF
--- a/src/Hooks/useFiles.ts
+++ b/src/Hooks/useFiles.ts
@@ -730,6 +730,7 @@ export const useFiles = ({ note }: Props) => {
     showActionsMenu,
     attachedFiles,
     allFiles,
+    handleFileAction,
     handlePressAttachFile,
     uploadFileFromCameraOrImageGallery,
     attachFileToNote,

--- a/src/Hooks/useFiles.ts
+++ b/src/Hooks/useFiles.ts
@@ -62,7 +62,7 @@ export const useFiles = ({ note }: Props) => {
   }, [application.items, filesService.sortByName, note])
 
   const reloadAllFiles = useCallback(() => {
-    setAllFiles((application.items.getItems(ContentType.File) as SNFile[]).sort(filesService.sortByName) as SNFile[])
+    setAllFiles(application.items.getItems<SNFile>(ContentType.File).sort(filesService.sortByName) as SNFile[])
   }, [application.items, filesService.sortByName])
 
   const deleteFileAtPath = useCallback(async (path: string) => {

--- a/src/Hooks/useFiles.ts
+++ b/src/Hooks/useFiles.ts
@@ -8,22 +8,11 @@ import {
   UploadedFileItemActionType,
 } from '@Root/Screens/UploadedFilesList/UploadedFileItemAction'
 import { Tabs } from '@Screens/UploadedFilesList/UploadedFilesList'
-import {
-  ButtonType,
-  ChallengeReason,
-  ClientDisplayableError,
-  ContentType,
-  SNFile,
-  SNNote,
-} from '@standardnotes/snjs'
+import { ButtonType, ChallengeReason, ClientDisplayableError, ContentType, SNFile, SNNote } from '@standardnotes/snjs'
 import { CustomActionSheetOption, useCustomActionSheet } from '@Style/CustomActionSheet'
 import { useCallback, useEffect, useState } from 'react'
 import { Platform } from 'react-native'
-import DocumentPicker, {
-  DocumentPickerResponse,
-  isInProgress,
-  pickMultiple,
-} from 'react-native-document-picker'
+import DocumentPicker, { DocumentPickerResponse, isInProgress, pickMultiple } from 'react-native-document-picker'
 import FileViewer from 'react-native-file-viewer'
 import RNFS, { exists } from 'react-native-fs'
 import { Asset, launchCamera, launchImageLibrary, MediaType } from 'react-native-image-picker'
@@ -69,18 +58,12 @@ export const useFiles = ({ note }: Props) => {
   const filesService = application.getFilesService()
 
   const reloadAttachedFiles = useCallback(() => {
-    setAttachedFiles(
-      application.items.getFilesForNote(note).sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
-    )
-  }, [application, note])
+    setAttachedFiles(application.items.getFilesForNote(note).sort(filesService.sortByName))
+  }, [application.items, filesService.sortByName, note])
 
   const reloadAllFiles = useCallback(() => {
-    setAllFiles(
-      application.items
-        .getItems(ContentType.File)
-        .sort((a, b) => (a.created_at < b.created_at ? 1 : -1)) as SNFile[]
-    )
-  }, [application])
+    setAllFiles((application.items.getItems(ContentType.File) as SNFile[]).sort(filesService.sortByName) as SNFile[])
+  }, [application.items, filesService.sortByName])
 
   const deleteFileAtPath = useCallback(async (path: string) => {
     try {
@@ -259,10 +242,7 @@ export const useFiles = ({ note }: Props) => {
 
   const authorizeProtectedActionForFile = useCallback(
     async (file: SNFile, challengeReason: ChallengeReason) => {
-      const authorizedFiles = await application.protections.authorizeProtectedActionForFiles(
-        [file],
-        challengeReason
-      )
+      const authorizedFiles = await application.protections.authorizeProtectedActionForFiles([file], challengeReason)
       return authorizedFiles.length > 0 && authorizedFiles.includes(file)
     },
     [application]
@@ -536,8 +516,7 @@ export const useFiles = ({ note }: Props) => {
         },
       },
     ]
-    const osSpecificOptions =
-      Platform.OS === 'android' ? options.filter(option => option.key !== 'library') : options
+    const osSpecificOptions = Platform.OS === 'android' ? options.filter(option => option.key !== 'library') : options
     showActionSheet({
       title: 'Choose action',
       options: osSpecificOptions,
@@ -583,10 +562,7 @@ export const useFiles = ({ note }: Props) => {
       let isAuthorizedForAction = true
 
       if (file.protected && action.type !== UploadedFileItemActionType.ToggleFileProtection) {
-        isAuthorizedForAction = await authorizeProtectedActionForFile(
-          file,
-          ChallengeReason.AccessProtectedFile
-        )
+        isAuthorizedForAction = await authorizeProtectedActionForFile(file, ChallengeReason.AccessProtectedFile)
       }
 
       if (!isAuthorizedForAction) {

--- a/src/Lib/FilesService.ts
+++ b/src/Lib/FilesService.ts
@@ -4,12 +4,7 @@ import { Buffer } from 'buffer'
 import { Base64 } from 'js-base64'
 import { PermissionsAndroid, Platform } from 'react-native'
 import { DocumentPickerResponse } from 'react-native-document-picker'
-import RNFS, {
-  CachesDirectoryPath,
-  DocumentDirectoryPath,
-  DownloadDirectoryPath,
-  read,
-} from 'react-native-fs'
+import RNFS, { CachesDirectoryPath, DocumentDirectoryPath, DownloadDirectoryPath, read } from 'react-native-fs'
 import { Asset } from 'react-native-image-picker'
 
 type TGetFileDestinationPath = {
@@ -33,9 +28,7 @@ export class FilesService extends ApplicationService {
     if (Platform.OS !== 'android') {
       return true
     }
-    const grantedStatus = await PermissionsAndroid.request(
-      PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
-    )
+    const grantedStatus = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE)
     if (grantedStatus === PermissionsAndroid.RESULTS.GRANTED) {
       return true
     }
@@ -60,10 +53,7 @@ export class FilesService extends ApplicationService {
     return file.fileName as string
   }
 
-  async readFile(
-    file: DocumentPickerResponse | Asset,
-    onChunk: OnChunkCallback
-  ): Promise<FileSelectionResponse> {
+  async readFile(file: DocumentPickerResponse | Asset, onChunk: OnChunkCallback): Promise<FileSelectionResponse> {
     const fileUri = (Platform.OS === 'ios' ? decodeURI(file.uri!) : file.uri) as string
 
     let positionShift = 0
@@ -88,5 +78,9 @@ export class FilesService extends ApplicationService {
       name: fileName,
       mimeType: file.type || '',
     }
+  }
+
+  sortByName(file1: SNFile, file2: SNFile): number {
+    return file1.name.toLocaleLowerCase() > file2.name.toLocaleLowerCase() ? 1 : -1
   }
 }

--- a/src/ModalStack.tsx
+++ b/src/ModalStack.tsx
@@ -112,9 +112,7 @@ export const MainStackComponent = ({ env }: { env: TEnvironment }) => {
                 testID="headerButton"
                 disabled={disabled}
                 title={Platform.OS === 'ios' ? 'Done' : ''}
-                iconName={
-                  Platform.OS === 'ios' ? undefined : ThemeService.nameForIcon(ICON_CHECKMARK)
-                }
+                iconName={Platform.OS === 'ios' ? undefined : ThemeService.nameForIcon(ICON_CHECKMARK)}
                 onPress={onPress}
               />
             </HeaderButtons>
@@ -127,9 +125,7 @@ export const MainStackComponent = ({ env }: { env: TEnvironment }) => {
                   title={'Destroy Data'}
                   onPress={async () => {
                     await application?.deviceInterface?.removeAllRawStorageValues()
-                    await application?.deviceInterface?.removeAllRawDatabasePayloads(
-                      application?.identifier
-                    )
+                    await application?.deviceInterface?.removeAllRawDatabasePayloads(application?.identifier)
                     application?.deinit(DeinitSource.SignOut)
                   }}
                 />
@@ -151,9 +147,7 @@ export const MainStackComponent = ({ env }: { env: TEnvironment }) => {
                 testID="headerButton"
                 disabled={disabled}
                 title={Platform.OS === 'ios' ? 'Done' : ''}
-                iconName={
-                  Platform.OS === 'ios' ? undefined : ThemeService.nameForIcon(ICON_CHECKMARK)
-                }
+                iconName={Platform.OS === 'ios' ? undefined : ThemeService.nameForIcon(ICON_CHECKMARK)}
                 onPress={onPress}
               />
             </HeaderButtons>
@@ -232,15 +226,13 @@ export const MainStackComponent = ({ env }: { env: TEnvironment }) => {
         options={({ route }) => ({
           title: 'Authenticate',
           headerLeft: () => undefined,
-          headerTitle: ({ children }) => (
-            <HeaderTitleView title={route.params?.title ?? (children || '')} />
-          ),
+          headerTitle: ({ children }) => <HeaderTitleView title={route.params?.title ?? (children || '')} />,
         })}
         component={Authenticate}
       />
       <MainStack.Screen
         name={SCREEN_UPLOADED_FILES_LIST}
-        options={() => ({
+        options={({ route }) => ({
           title: 'Files',
           headerLeft: ({ disabled, onPress }) => (
             <HeaderButtons HeaderButtonComponent={IoniconsHeaderButton}>
@@ -253,6 +245,9 @@ export const MainStackComponent = ({ env }: { env: TEnvironment }) => {
               />
             </HeaderButtons>
           ),
+          headerTitle: ({ children }) => {
+            return <HeaderTitleView title={route.params?.title ?? (children || '')} />
+          },
         })}
         component={UploadedFilesList}
       />

--- a/src/ModalStack.tsx
+++ b/src/ModalStack.tsx
@@ -47,7 +47,6 @@ export type ModalStackNavigatorParamList = {
   }
   [SCREEN_UPLOADED_FILES_LIST]: HeaderTitleParams & {
     note: SNNote
-    shouldShowAllFiles: boolean
   }
   [SCREEN_INPUT_MODAL_PASSCODE]: undefined
   [SCREEN_AUTHENTICATE]: {

--- a/src/Screens/SideMenu/Files.tsx
+++ b/src/Screens/SideMenu/Files.tsx
@@ -14,6 +14,7 @@ import {
   styles,
 } from '@Root/Screens/SideMenu/Files.styled'
 import { SideMenuOptionIconDescriptionType } from '@Root/Screens/SideMenu/SideMenuSection'
+import { UploadedFileItemActionType } from '@Screens/UploadedFilesList/UploadedFileItemAction'
 import { SNNote } from '@standardnotes/snjs'
 import React, { FC } from 'react'
 
@@ -26,7 +27,7 @@ export const Files: FC<Props> = ({ note }) => {
   const filesService = application.getFilesService()
 
   const navigation = useNavigation<AppStackNavigationProp<typeof SCREEN_COMPOSE>['navigation']>()
-  const { showActionsMenu, handlePressAttachFile, attachedFiles } = useFiles({ note })
+  const { showActionsMenu, handlePressAttachFile, attachedFiles, handleFileAction } = useFiles({ note })
 
   const openFilesScreen = () => {
     navigation.navigate(SCREEN_UPLOADED_FILES_LIST, { note })
@@ -42,7 +43,13 @@ export const Files: FC<Props> = ({ note }) => {
             <SideMenuCellStyled
               text={file.name}
               key={file.uuid}
-              onSelect={() => showActionsMenu(file)}
+              onSelect={() => {
+                void handleFileAction({
+                  type: UploadedFileItemActionType.PreviewFile,
+                  payload: file,
+                })
+              }}
+              onLongPress={() => showActionsMenu(file)}
               iconDesc={{
                 side: 'right',
                 type: SideMenuOptionIconDescriptionType.CustomComponent,

--- a/src/Screens/SideMenu/Files.tsx
+++ b/src/Screens/SideMenu/Files.tsx
@@ -21,23 +21,19 @@ type Props = {
   note: SNNote
 }
 
-const MaximumVisibleFilesCount = 3
-
 export const Files: FC<Props> = ({ note }) => {
   const application = useSafeApplicationContext()
 
   const navigation = useNavigation<AppStackNavigationProp<typeof SCREEN_COMPOSE>['navigation']>()
   const { showActionsMenu, handlePressAttachFile, attachedFiles } = useFiles({ note })
 
-  const openFilesScreen = (shouldShowAllFiles: boolean) => {
-    navigation.navigate(SCREEN_UPLOADED_FILES_LIST, { note, shouldShowAllFiles })
+  const openFilesScreen = () => {
+    navigation.navigate(SCREEN_UPLOADED_FILES_LIST, { note })
   }
-
-  const isFilesListTruncated = attachedFiles.length > MaximumVisibleFilesCount
 
   return (
     <FilesContainer>
-      {attachedFiles.slice(0, MaximumVisibleFilesCount).map(file => {
+      {attachedFiles.map(file => {
         const iconType = application.iconsController.getIconForFileType(file.mimeType)
 
         return (
@@ -61,13 +57,10 @@ export const Files: FC<Props> = ({ note }) => {
           </FileItemContainer>
         )
       })}
-      <SideMenuCellAttachNewFile
-        text={'Attach new file'}
-        onSelect={() => handlePressAttachFile()}
-      />
+      <SideMenuCellAttachNewFile text={'Upload new file'} onSelect={() => handlePressAttachFile()} />
       <SideMenuCellShowAllFiles
-        text={isFilesListTruncated ? 'Show more files' : 'Show all files'}
-        onSelect={() => openFilesScreen(!isFilesListTruncated)}
+        text={'Show all files'}
+        onSelect={() => openFilesScreen()}
         cellContentStyle={styles.cellContentStyle}
       />
     </FilesContainer>

--- a/src/Screens/SideMenu/Files.tsx
+++ b/src/Screens/SideMenu/Files.tsx
@@ -23,6 +23,7 @@ type Props = {
 
 export const Files: FC<Props> = ({ note }) => {
   const application = useSafeApplicationContext()
+  const filesService = application.getFilesService()
 
   const navigation = useNavigation<AppStackNavigationProp<typeof SCREEN_COMPOSE>['navigation']>()
   const { showActionsMenu, handlePressAttachFile, attachedFiles } = useFiles({ note })
@@ -33,7 +34,7 @@ export const Files: FC<Props> = ({ note }) => {
 
   return (
     <FilesContainer>
-      {attachedFiles.map(file => {
+      {attachedFiles.sort(filesService.sortByName).map(file => {
         const iconType = application.iconsController.getIconForFileType(file.mimeType)
 
         return (

--- a/src/Screens/UploadedFilesList/UploadedFileItem.styled.ts
+++ b/src/Screens/UploadedFilesList/UploadedFileItem.styled.ts
@@ -42,6 +42,9 @@ export const FileName = styled(Text)`
 export const FileDateAndSizeContainer = styled.View`
   flex-direction: row;
   align-items: center;
+`
+export const FileDateAndSize = styled(Text)`
   color: ${({ theme }) => theme.stylekitAbbey};
+  font-weight: normal;
   font-size: 12px;
 `

--- a/src/Screens/UploadedFilesList/UploadedFileItem.styled.ts
+++ b/src/Screens/UploadedFilesList/UploadedFileItem.styled.ts
@@ -1,4 +1,5 @@
 import { SnIcon } from '@Root/Components/SnIcon'
+import { Text } from '@Screens/SideMenu/SideMenuCell.styled'
 import { StyleSheet } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -33,10 +34,10 @@ export const LockIconStyled = styled(SnIcon)`
 export const FileDetailsContainer = styled.View`
   flex-shrink: 1;
 `
-export const FileName = styled.Text`
+export const FileName = styled(Text)`
+  font-weight: normal;
   font-size: 16px;
   margin-bottom: 4px;
-  color: ${({ theme }) => theme.stylekitCodGray};
 `
 export const FileDateAndSizeContainer = styled.View`
   flex-direction: row;

--- a/src/Screens/UploadedFilesList/UploadedFileItem.styled.ts
+++ b/src/Screens/UploadedFilesList/UploadedFileItem.styled.ts
@@ -1,5 +1,6 @@
 import { SnIcon } from '@Root/Components/SnIcon'
 import { Text } from '@Screens/SideMenu/SideMenuCell.styled'
+import { hexToRGBA } from '@Style/Utils'
 import { StyleSheet } from 'react-native'
 import styled from 'styled-components/native'
 
@@ -23,7 +24,7 @@ export const FileDetailsWithExtraIconsContainer = styled.View`
   flex-shrink: 1;
   flex-grow: 1;
   align-items: center;
-  border-bottom-color: ${({ theme }) => theme.stylekitIron};
+  border-bottom-color: ${({ theme }) => hexToRGBA(theme.stylekitBorderColor, 0.75)};
   border-bottom-width: 1px;
   padding-bottom: 12px;
 `
@@ -43,8 +44,11 @@ export const FileDateAndSizeContainer = styled.View`
   flex-direction: row;
   align-items: center;
 `
-export const FileDateAndSize = styled(Text)`
-  color: ${({ theme }) => theme.stylekitAbbey};
+export const FileDateAndSize = styled.Text`
+  color: ${({ theme }) => {
+    return theme.stylekitForegroundColor
+  }};
+  opacity: 0.5;
   font-weight: normal;
   font-size: 12px;
 `

--- a/src/Screens/UploadedFilesList/UploadedFileItem.tsx
+++ b/src/Screens/UploadedFilesList/UploadedFileItem.tsx
@@ -7,10 +7,11 @@ import { UploadedFileItemActionType } from '@Screens/UploadedFilesList/UploadedF
 import { formatSizeToReadableString } from '@standardnotes/filepicker'
 import { SNFile, SNNote } from '@standardnotes/snjs'
 import React, { FC, useContext, useEffect, useState } from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import { ThemeContext } from 'styled-components'
 import {
   FileDataContainer,
+  FileDateAndSize,
   FileDateAndSizeContainer,
   FileDetailsContainer,
   FileDetailsWithExtraIconsContainer,
@@ -60,9 +61,9 @@ export const UploadedFileItem: FC<UploadedFileItemProps> = ({ file, note }) => {
             <FileDetailsContainer>
               <FileName>{fileName}</FileName>
               <FileDateAndSizeContainer>
-                <Text>
+                <FileDateAndSize>
                   {file.created_at.toLocaleString()} · {formatSizeToReadableString(file.size)}
-                </Text>
+                </FileDateAndSize>
                 {file.protected && (
                   <SnIcon
                     type={'lock-filled'}

--- a/src/Screens/UploadedFilesList/UploadedFileItem.tsx
+++ b/src/Screens/UploadedFilesList/UploadedFileItem.tsx
@@ -3,6 +3,7 @@ import { SnIcon } from '@Root/Components/SnIcon'
 import { useFiles } from '@Root/Hooks/useFiles'
 import { useSafeApplicationContext } from '@Root/Hooks/useSafeApplicationContext'
 import { SCREEN_COMPOSE } from '@Root/Screens/screens'
+import { UploadedFileItemActionType } from '@Screens/UploadedFilesList/UploadedFileItemAction'
 import { formatSizeToReadableString } from '@standardnotes/filepicker'
 import { SNFile, SNNote } from '@standardnotes/snjs'
 import React, { FC, useContext, useEffect, useState } from 'react'
@@ -30,7 +31,7 @@ export const UploadedFileItem: FC<UploadedFileItemProps> = ({ file, note }) => {
   const application = useSafeApplicationContext()
   const theme = useContext(ThemeContext)
 
-  const { showActionsMenu } = useFiles({ note })
+  const { showActionsMenu, handleFileAction } = useFiles({ note })
 
   const [fileName, setFileName] = useState(file.name)
 
@@ -41,7 +42,15 @@ export const UploadedFileItem: FC<UploadedFileItemProps> = ({ file, note }) => {
   const iconType = application.iconsController.getIconForFileType(file.mimeType)
 
   return (
-    <TouchableOpacity onPress={() => showActionsMenu(file)}>
+    <TouchableOpacity
+      onPress={() => {
+        void handleFileAction({
+          type: UploadedFileItemActionType.PreviewFile,
+          payload: file,
+        })
+      }}
+      onLongPress={() => showActionsMenu(file)}
+    >
       <View>
         <FileDataContainer>
           <FileIconContainer>

--- a/src/Screens/UploadedFilesList/UploadedFilesList.tsx
+++ b/src/Screens/UploadedFilesList/UploadedFilesList.tsx
@@ -31,16 +31,14 @@ type Props = ModalStackNavigationProp<typeof SCREEN_UPLOADED_FILES_LIST>
 
 export const UploadedFilesList: FC<Props> = props => {
   const { AttachedFiles, AllFiles } = Tabs
-  const { note, shouldShowAllFiles } = props.route.params
+  const { note } = props.route.params
 
   const theme = useContext(ThemeContext)
 
   const styles = useUploadedFilesListStyles()
   const navigation = useNavigation()
 
-  const [currentTab, setCurrentTab] = useState(() => {
-    return shouldShowAllFiles ? AllFiles : AttachedFiles
-  })
+  const [currentTab, setCurrentTab] = useState(AllFiles)
   const [searchString, setSearchString] = useState('')
   const [filesListScrolled, setFilesListScrolled] = useState(false)
 
@@ -86,13 +84,7 @@ export const UploadedFilesList: FC<Props> = props => {
     [scrollListToTop]
   )
 
-  const {
-    centeredView,
-    header,
-    headerTabContainer,
-    noAttachmentsIcon,
-    noAttachmentsIconContainer,
-  } = styles
+  const { centeredView, header, headerTabContainer, noAttachmentsIcon, noAttachmentsIconContainer } = styles
 
   const onScroll = () => {
     if (filesListScrolled) {
@@ -102,14 +94,7 @@ export const UploadedFilesList: FC<Props> = props => {
   }
 
   const renderItem: ListRenderItem<SNFile> = ({ item }) => {
-    return (
-      <UploadedFileItem
-        key={item.uuid}
-        file={item}
-        note={note}
-        isAttachedToNote={attachedFiles.includes(item)}
-      />
-    )
+    return <UploadedFileItem key={item.uuid} file={item} note={note} isAttachedToNote={attachedFiles.includes(item)} />
   }
 
   return (
@@ -124,10 +109,7 @@ export const UploadedFilesList: FC<Props> = props => {
             >
               <TabText isActive={currentTab === AttachedFiles}>Attached</TabText>
             </HeaderTabItem>
-            <HeaderTabItem
-              isActive={currentTab === AllFiles}
-              onTouchEnd={() => setCurrentTab(AllFiles)}
-            >
+            <HeaderTabItem isActive={currentTab === AllFiles} onTouchEnd={() => setCurrentTab(AllFiles)}>
               <TabText isActive={currentTab === AllFiles}>All files</TabText>
             </HeaderTabItem>
           </View>


### PR DESCRIPTION
Internal links: [#1](https://app.asana.com/0/1201653402817596/1202178314278387), [#2](https://app.asana.com/0/1201653402817596/1202178702318663), [#3](https://app.asana.com/0/1201653402817596/1202178702318665)

- Don't truncate file list in note side menu
- Files screen is not themed properly with dark themes
- Tap selection on file should trigger preview; long press should show action sheet
- Files should be sorted by name